### PR TITLE
Integrate Paddle as Payment Gateway and remove Stripe Subscription Management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 # Set this environment variable to support webhooks — https://stripe.com/docs/webhooks#verify-events
 STRIPE_WEBHOOK_SECRET=
+
+# Paddle for payments
+# https://developer.paddle.com/api-reference/about/authentication#generate-authentication
+PADDLE_ENV='sandbox'
+PADDLE_SECRET_CLIENT_KEY=
+PADDLE_SERVER_SECRET_KEY=
+PADDLE_WEBHOOK_SECRET=

--- a/emails/welcome-email.tsx
+++ b/emails/welcome-email.tsx
@@ -1,0 +1,103 @@
+import { ORGNISE_LOGO } from "@/lib/constants";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+import Footer from "./component/footer";
+
+export default function WelcomeEmail({
+  name = "John Doe",
+  email = "john@doe.io",
+}: {
+  name: string | null;
+  email: string;
+}) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Welcome to Orgnise.in</Preview>
+      <Tailwind>
+        <Body className="mx-auto my-auto bg-white font-sans">
+          <Container className="mx-auto my-10 max-w-[500px] rounded border border-solid border-gray-200 px-10 py-5">
+            <Section className="mt-8">
+              <Img
+                src={ORGNISE_LOGO}
+                height="40"
+                alt="Orgnise Logo"
+                className="mx-auto my-0"
+              />
+            </Section>
+            <Heading className="mx-0 my-7 p-0 text-center text-xl font-semibold text-black">
+              Welcome to Orgnise.in
+            </Heading>
+            <Section className="my-8">
+              {/* <Img src={THUMBNAIL} alt="Orgnise" className="max-w-[500px]" /> */}
+            </Section>
+            <Text className="text-sm leading-6 text-black">
+              Thanks for signing up{name && `, ${name}`}!
+            </Text>
+            <Text className="text-sm leading-6 text-black">
+              My name is Sonu Sharma, and I&apos;m the founder of Orgnise.in -
+              the modern tool for managing your knowledge base. We&apos;re
+              excited to have you on board!
+            </Text>
+            <Text className="text-sm leading-6 text-black">
+              Here are a few things you can do:
+            </Text>
+            <Text className="ml-1 text-sm leading-4 text-black">
+              ◆ Create a{" "}
+              <Link
+                href="https://orgnise.in/help/article/how-to-create-a-team"
+                className="font-medium text-blue-600 no-underline"
+              >
+                new team
+              </Link>{" "}
+              and{" "}
+              <Link
+                href="https://orgnise.in/help/article/how-to-create-workspace"
+                className="font-medium text-blue-600 no-underline"
+              >
+                add a workspace
+              </Link>
+            </Text>
+            <Text className="ml-1 text-sm leading-4 text-black">
+              ◆ Create your first{" "}
+              <Link
+                href="https://orgnise.in/help/article/what-is-collection"
+                className="font-medium text-blue-600 no-underline"
+              >
+                collection{" "}
+              </Link>
+              and{" "}
+              <Link
+                href="https://orgnise.in/help/article/what-is-page"
+                className="font-medium text-blue-600 no-underline"
+              >
+                page
+              </Link>
+            </Text>
+
+            <Text className="text-sm leading-6 text-black">
+              Let me know if you have any questions or feedback. I&apos;m always
+              happy to help!
+            </Text>
+            <Text className="text-sm font-light leading-6 text-gray-400">
+              Sonu from Orgnise
+            </Text>
+
+            <Footer email={email} marketing />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@auth/core": "^0.19.0",
         "@auth/mongodb-adapter": "^2.0.10",
+        "@paddle/paddle-js": "^1.2.0",
+        "@paddle/paddle-node-sdk": "^1.4.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
@@ -1101,6 +1103,20 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+    },
+    "node_modules/@paddle/paddle-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@paddle/paddle-js/-/paddle-js-1.2.0.tgz",
+      "integrity": "sha512-NPjFH5uK+AsMIxcyT2ERhJXhAcvotox45FUbxeuoIONMp6cM7/xse5X2qBz9ZoCaKGi5RdS8cdmd1bLob1I+wA=="
+    },
+    "node_modules/@paddle/paddle-node-sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@paddle/paddle-node-sdk/-/paddle-node-sdk-1.4.0.tgz",
+      "integrity": "sha512-SWarh93amMZy2UTPqHgFz15MyTPmhe5Ggn+wgdgPE8QvR8dJVJC74HsGvuSLUJMyB04UpvMTIF8HJayt5d3QEQ==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.7.0"
+      }
     },
     "node_modules/@panva/hkdf": {
       "version": "1.1.1",
@@ -7502,6 +7518,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@auth/core": "^0.19.0",
     "@auth/mongodb-adapter": "^2.0.10",
+    "@paddle/paddle-js": "^1.2.0",
+    "@paddle/paddle-node-sdk": "^1.4.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",

--- a/src/app/(dashboard)/[team_slug]/settings/billing/billing-page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/settings/billing/billing-page-client.tsx
@@ -19,8 +19,10 @@ import TeamBillingSettingsLoading from "./loading";
 
 export default function TeamBillingPageClient({
   PADDLE_SECRET_CLIENT_KEY,
+  PADDLE_ENV,
 }: {
   PADDLE_SECRET_CLIENT_KEY?: string;
+  PADDLE_ENV: "sandbox" | "production";
 }) {
   const [isManageSubscriptionClicked, setManageSubscriptionClicked] =
     useState(false);
@@ -33,6 +35,7 @@ export default function TeamBillingPageClient({
 
   const { UpgradePlanModal, setShowUpgradePlanModal } = useUpgradePlanModal(
     PADDLE_SECRET_CLIENT_KEY,
+    PADDLE_ENV,
   );
 
   const [billingStart, billingEnd] = useMemo(() => {

--- a/src/app/(dashboard)/[team_slug]/settings/billing/billing-page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/settings/billing/billing-page-client.tsx
@@ -9,41 +9,52 @@ import { ProgressBar } from "@/components/ui/progress-bar";
 import { useRouterStuff } from "@/lib/hooks";
 import useUsage from "@/lib/hooks/use-usage";
 import useTeam from "@/lib/swr/use-team";
-import { getFirstAndLastDay } from "@/lib/utility/datetime";
+import { getFirstAndLastDay2 } from "@/lib/utility/datetime";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import Confetti from "react-dom-confetti";
 import { toast } from "sonner";
-import { mutate } from "swr";
+
 import TeamBillingSettingsLoading from "./loading";
 
-export default function TeamBillingPageClient() {
+export default function TeamBillingPageClient({
+  PADDLE_SECRET_CLIENT_KEY,
+}: {
+  PADDLE_SECRET_CLIENT_KEY?: string;
+}) {
   const [isManageSubscriptionClicked, setManageSubscriptionClicked] =
     useState(false);
-  const { activeTeam, loading, nextPlan, stripeId } = useTeam();
+  const { activeTeam, loading, nextPlan, subscriptionId, mutate } = useTeam();
   const { limit, usage } = useUsage();
   const plan = activeTeam?.plan ?? "free";
   const billingCycleStart = activeTeam?.billingCycleStart;
   const { queryParams, router } = useRouterStuff();
   const searchParams = useSearchParams();
 
-  const { UpgradePlanModal, setShowUpgradePlanModal } = useUpgradePlanModal();
+  const { UpgradePlanModal, setShowUpgradePlanModal } = useUpgradePlanModal(
+    PADDLE_SECRET_CLIENT_KEY,
+  );
 
   const [billingStart, billingEnd] = useMemo(() => {
     if (billingCycleStart) {
-      const { firstDay, lastDay } = getFirstAndLastDay(billingCycleStart);
+      const { firstDay, lastDay } = getFirstAndLastDay2(
+        billingCycleStart,
+        (activeTeam?.billingInterval as "year" | "month") ?? "month",
+      );
       const start = firstDay.toLocaleDateString("en-us", {
         month: "short",
         day: "numeric",
+        year: "numeric",
       });
       const end = lastDay.toLocaleDateString("en-us", {
         month: "short",
         day: "numeric",
+        year: "numeric",
       });
       return [start, end];
     }
     return [];
-  }, [billingCycleStart]);
+  }, [activeTeam?.billingInterval, billingCycleStart]);
 
   const [confetti, setConfetti] = useState(false);
 
@@ -52,10 +63,10 @@ export default function TeamBillingPageClient() {
       toast.success("Upgrade success!");
       setConfetti(true);
       setTimeout(() => {
-        mutate(`/api/teams/${activeTeam?.meta.slug}`);
+        mutate().then(() => {});
       }, 1000);
     }
-  }, [searchParams, activeTeam?.meta?.slug]);
+  }, [mutate, searchParams]);
 
   if (loading) {
     return <TeamBillingSettingsLoading />;
@@ -81,30 +92,86 @@ export default function TeamBillingPageClient() {
                 .
               </>
             )}
+            {/* {activeTeam?.currentBillingPeriod ? (
+              <>
+                {" "}
+                Your current billing period is{" "}
+                <span className="font-medium text-secondary-foreground">
+                  {new Date(
+                    activeTeam?.currentBillingPeriod?.startsAt,
+                  ).toLocaleDateString()}{" "}
+                  -{" "}
+                  {new Date(
+                    activeTeam?.currentBillingPeriod?.endsAt,
+                  ).toLocaleDateString()}
+                </span>
+                .
+              </>
+            ) : (
+              billingStart &&
+              billingEnd && (
+                <>
+                  {" "}
+                  Current billing cycle:{" "}
+                  <span className="font-medium text-secondary-foreground">
+                    {billingStart} - {billingEnd}
+                  </span>
+                  .
+                </>
+              )
+            )} */}
           </p>
-          {stripeId && (
-            <div>
-              <Button2
-                text="Manage Subscription"
-                variant="secondary"
-                className="h-9"
-                onClick={() => {
-                  setManageSubscriptionClicked(true);
-                  fetch(`/api/teams/${activeTeam?.meta?.slug}/billing/manage`, {
-                    method: "POST",
-                  })
-                    .then(async (res) => {
-                      const url = await res.json();
-                      router.push(url);
-                    })
-                    .catch((err) => {
-                      alert(err);
-                      setManageSubscriptionClicked(false);
-                    });
-                }}
-                loading={isManageSubscriptionClicked}
-              />
+          {activeTeam?.scheduledChange?.action == "cancel" ? (
+            <div className="w-full rounded-xl border border-inherit p-4">
+              <p className="font-medium  ">Subscription cancellation status</p>
+              <p className="text-sm text-muted-foreground/90">
+                Your subscription is scheduled to be cancelled at the end of the
+                current billing cycle which is{" "}
+                <span className="font-medium text-secondary-foreground">
+                  {new Date(
+                    activeTeam?.scheduledChange?.effectiveAt,
+                  ).toLocaleDateString()}
+                </span>
+                . Until then, you can continue to use all the features of your
+                current plan.
+              </p>
             </div>
+          ) : (
+            subscriptionId && (
+              <></>
+              // <Button2
+              //   text="Manage Subscription"
+              //   variant="secondary"
+              //   className="h-9"
+              //   onClick={async () => {
+              //     setManageSubscriptionClicked(true);
+              //     fetch(
+              //       `/api/teams/${activeTeam?.meta?.slug}/billing/cancel-subscription`,
+              //       {
+              //         method: "POST",
+              //       },
+              //     )
+              //       .then(async (res) => {
+              //         const data = await res.json();
+              //         if (res.ok) {
+              //           await mutate();
+              //           toast.success("Subscription cancelled successfully");
+              //         } else {
+              //           console.log(data);
+              //           toast.error(
+              //             data?.detail ?? "Failed to cancel subscription",
+              //           );
+              //         }
+              //         setManageSubscriptionClicked(false);
+              //       })
+              //       .catch((err) => {
+              //         alert(err.message);
+              //         setManageSubscriptionClicked(false);
+              //       });
+              //   }}
+              //   loading={isManageSubscriptionClicked}
+              // />
+            )
           )}
         </div>
         <div className="grid divide-y divide-border border-y border-border">
@@ -146,35 +213,37 @@ export default function TeamBillingPageClient() {
           ) : (
             <div className="h-3 w-28 animate-pulse rounded-full bg-secondary-foreground/20" />
           )}
-          <TeamPermissionView permission="UPGRADE_TEAM_PLAN">
-            <div>
-              {plan ? (
-                plan === "enterprise" || plan === "business" ? (
-                  <a
-                    href="https://orgnise.in/enterprise"
-                    target="_blank"
-                    className="inline-flex items-center justify-center rounded-md border border-violet-600 bg-violet-600 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-white hover:text-violet-600 focus:outline-none"
-                  >
-                    Contact Sales
-                  </a>
+          {activeTeam?.scheduledChange?.action != "cancel" && (
+            <TeamPermissionView permission="UPGRADE_TEAM_PLAN">
+              <div>
+                {plan ? (
+                  plan === "enterprise" || plan === "business" ? (
+                    <a
+                      href="https://orgnise.in/enterprise"
+                      target="_blank"
+                      className="inline-flex items-center justify-center rounded-md border border-violet-600 bg-violet-600 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-white hover:text-violet-600 focus:outline-none"
+                    >
+                      Contact Sales
+                    </a>
+                  ) : (
+                    <Button2
+                      text={`Upgrade to ${nextPlan.name}`}
+                      onClick={() =>
+                        queryParams({
+                          set: {
+                            upgrade: nextPlan.name.toLowerCase(),
+                          },
+                        })
+                      }
+                      variant="default"
+                    />
+                  )
                 ) : (
-                  <Button2
-                    text={`Upgrade to ${nextPlan.name}`}
-                    onClick={() =>
-                      queryParams({
-                        set: {
-                          upgrade: nextPlan.name.toLowerCase(),
-                        },
-                      })
-                    }
-                    variant="default"
-                  />
-                )
-              ) : (
-                <div className="h-10 w-24 animate-pulse rounded-md bg-accent/20" />
-              )}
-            </div>
-          </TeamPermissionView>
+                  <div className="h-10 w-24 animate-pulse rounded-md bg-accent/20" />
+                )}
+              </div>
+            </TeamPermissionView>
+          )}
         </div>
         <UpgradePlanModal />
       </div>

--- a/src/app/(dashboard)/[team_slug]/settings/billing/billing-page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/settings/billing/billing-page-client.tsx
@@ -205,7 +205,7 @@ export default function TeamBillingPageClient({
           {plan ? (
             <p className="text-sm text-secondary-foreground/65">
               {plan === "pro"
-                ? "You're on the Pro plan."
+                ? "You're on the Pro plan. Upgrade to unlock more features."
                 : plan === "business"
                   ? "Need more workspaces or pages? Contact us for an Enterprise quote."
                   : `For higher limits, upgrade to the ${nextPlan.name} plan.`}
@@ -219,11 +219,19 @@ export default function TeamBillingPageClient({
                 {plan ? (
                   plan === "enterprise" || plan === "business" ? (
                     <a
-                      href="https://orgnise.in/enterprise"
+                      href="https://orgnise.in/contact"
                       target="_blank"
                       className="inline-flex items-center justify-center rounded-md border border-violet-600 bg-violet-600 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-white hover:text-violet-600 focus:outline-none"
                     >
                       Contact Sales
+                    </a>
+                  ) : plan === "pro" ? (
+                    <a
+                      href="https://orgnise.in/enterprise"
+                      target="_blank"
+                      className="inline-flex items-center justify-center rounded-md border border-violet-600 bg-violet-600 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-white hover:text-violet-600 focus:outline-none"
+                    >
+                      Contact Us
                     </a>
                   ) : (
                     <Button2

--- a/src/app/(dashboard)/[team_slug]/settings/billing/page.tsx
+++ b/src/app/(dashboard)/[team_slug]/settings/billing/page.tsx
@@ -1,5 +1,9 @@
 import TeamBillingPageClient from "./billing-page-client";
 
 export default function TeamBillingPage() {
-  return <TeamBillingPageClient />;
+  return (
+    <TeamBillingPageClient
+      PADDLE_SECRET_CLIENT_KEY={process.env.PADDLE_SECRET_CLIENT_KEY}
+    />
+  );
 }

--- a/src/app/(dashboard)/[team_slug]/settings/billing/page.tsx
+++ b/src/app/(dashboard)/[team_slug]/settings/billing/page.tsx
@@ -4,6 +4,7 @@ export default function TeamBillingPage() {
   return (
     <TeamBillingPageClient
       PADDLE_SECRET_CLIENT_KEY={process.env.PADDLE_SECRET_CLIENT_KEY}
+      PADDLE_ENV={process.env.PADDLE_ENV as any}
     />
   );
 }

--- a/src/app/api/callback/paddle/route.ts
+++ b/src/app/api/callback/paddle/route.ts
@@ -1,0 +1,77 @@
+import { log } from "@/lib/functions/log";
+import mongodb from "@/lib/mongodb";
+import { Environment, EventEntity, EventName, LogLevel, Paddle } from '@paddle/paddle-node-sdk';
+import { NextResponse } from "next/server";
+import { subscriptionActivated } from "./subscription.activated";
+import { subscriptionUpdated } from "./subscription.updated";
+import { subscriptionCanceled } from "./subscription.canceled";
+
+const relevantEvents = new Set([
+  "subscription.activated",
+  "subscription.updated",
+  "subscription.canceled",
+])
+
+export const paddle = new Paddle(process.env.PADDLE_SERVER_SECRET_KEY ?? "", { environment: process.env.PADDLE_ENV === 'production' ? Environment.production : Environment.sandbox, logLevel: LogLevel.verbose });
+
+// POST /api/callback/paddle – listen to Paddle webhooks
+export const POST = async (req: Request) => {
+  try {
+    const buf = await req.text();
+    const signature = req.headers.get("Paddle-Signature") as string;
+    const webhookSecret = process.env.PADDLE_WEBHOOK_SECRET;
+    let event: EventEntity | null;
+
+    try {
+      if (!signature || !webhookSecret) {
+        console.log("❌ Invalid signature", signature, webhookSecret);
+        return new Response("Invalid signature", { status: 400 });
+      }
+      // event = Paddle.webhooks.constructEvent(buf, signature, webhookSecret);
+      event = paddle.webhooks.unmarshal(buf, webhookSecret, signature);
+      if (event == null) {
+        return new Response("event is null", { status: 400 });
+      }
+    } catch (err: any) {
+      console.log(`❌ Error message: ${err.message}`);
+      console.log('❌ Error:', {
+        signature,
+        webhookSecret
+      })
+      return new Response(`Webhook Error: ${err.message}`, {
+        status: 400,
+      });
+    }
+    console.log('👉 Paddle webhook event:', event);
+    if (relevantEvents.has(event.eventType)) {
+      console.log('\n 🪝 Paddle webhook event type:', event.eventType);
+      const client = await mongodb;
+      switch (event.eventType) {
+        case EventName.SubscriptionActivated:
+          await subscriptionActivated(event, client);
+          break;
+        case EventName.SubscriptionUpdated:
+          await subscriptionUpdated(event, client);
+          break;
+        case EventName.SubscriptionCanceled:
+          await subscriptionCanceled(event, client);
+          break;
+      }
+
+
+
+    }
+    return NextResponse.json({ received: true });
+  } catch (error: any) {
+    await log({
+      message: `Paddle webhook failed. Error: ${error.message}`,
+      type: "errors",
+    });
+    return new Response(
+      'Webhook error: "Webhook handler failed. View logs."',
+      {
+        status: 400,
+      },
+    );
+  }
+};

--- a/src/app/api/callback/paddle/subscription.activated.ts
+++ b/src/app/api/callback/paddle/subscription.activated.ts
@@ -1,0 +1,133 @@
+import { getTeamOwner } from "@/lib/api";
+import { getPlanFromPriceId } from "@/lib/constants/pricing";
+import { TeamDbSchema } from "@/lib/db-schema";
+import { log } from "@/lib/functions/log";
+import { databaseName } from "@/lib/mongodb";
+import { MongoClient, ObjectId } from "mongodb";
+import { sendEmailV2 } from "../../../../../emails";
+import UpgradeEmail from "../../../../../emails/upgrade-email";
+
+import { APP_DOMAIN } from "@/lib/constants";
+import { EventEntity, SubscriptionNotification } from '@paddle/paddle-node-sdk';
+
+// Handle event "subscription.activated"
+export async function subscriptionActivated(event: EventEntity, client: MongoClient) {
+
+  const teamsCollection = client.db(databaseName).collection<TeamDbSchema>("teams");
+
+  const subscription = event.data as SubscriptionNotification
+  const customData = subscription.customData as Record<string, any>;
+  const teamId = customData.teamId as string | undefined
+  const subscriptionId = subscription.id;
+  const priceId = subscription.items[0].price?.id;
+  const scheduledChange = subscription.scheduledChange;
+  const interval = subscription.items[0].price?.billingCycle?.interval;
+  const status = subscription.status;
+  const productId = subscription.items[0].price?.productId;
+  const nextBilledAt = subscription.nextBilledAt;
+  const pausedAt = subscription.pausedAt;
+  const canceledAt = subscription.canceledAt;
+
+  if (
+    !teamId
+  ) {
+    await log({
+      message: "Missing teamId in Paddle webhook callback in Paddle webhook `subscription.activated` callback",
+      type: "errors",
+    });
+    return;
+  }
+
+
+  const plan = getPlanFromPriceId(priceId!);
+
+  if (!plan) {
+    await log({
+      message: "Invalid price ID:`" + `${priceId}` + '` in Paddle webhook `subscription.activated` callback',
+      type: "errors",
+    });
+    return;
+  }
+
+
+
+  const team = await teamsCollection.findOne({ _id: new ObjectId(teamId) });
+
+  if (!team) {
+    await log({
+      message:
+        "Team with Paddle ID *`" +
+        teamId +
+        "`* not found in Paddle webhook `subscription.activated` callback",
+      type: "errors",
+    });
+    return;
+  }
+
+
+  // when the team subscribes to a plan, set their Paddle customer ID
+  // in the database for easy identification in future webhook events
+  // also update the billingCycleStart to today's date
+  const result = await teamsCollection.updateOne(
+    { _id: team._id },
+    {
+      $set: {
+        subscriptionId: subscriptionId,
+        billingCycleStart: new Date().getDate(),
+        plan: plan.name.toLowerCase() as any,
+        subscription: {
+          status: status,
+          id: subscriptionId,
+          productId: productId!,
+          priceId: priceId!,
+          canceledAt: canceledAt ? new Date(canceledAt!) : undefined,
+          scheduledChange: scheduledChange,
+          nextBilledAt: nextBilledAt ? new Date(nextBilledAt!) : undefined,
+          pausedAt: pausedAt ? new Date(pausedAt!) : undefined,
+          interval: interval,
+          collectionMode: subscription.collectionMode,
+          currentBillingPeriod: subscription.currentBillingPeriod
+        },
+        limit: {
+          pages: plan.limits.pages!,
+          users: plan.limits.users!,
+          workspaces: plan.limits.workspaces!,
+        }
+      },
+    },
+  );
+
+
+
+  if (result.acknowledged) {
+    const teamOwner = await getTeamOwner(client, teamId);
+    if (!teamOwner) {
+      await log({
+        message:
+          "Team" + `<${APP_DOMAIN}/${team.meta.slug}|${team.name}>` + " with Subscription ID *`" +
+          subscriptionId +
+          "`* does not have an owner in Paddle webhook `subscription.activated` callback",
+        type: "errors",
+      });
+      return;
+    }
+    await sendEmailV2({
+      identifier: teamOwner.email!,
+      subject: `Thank you for upgrading to Orgnise.in ${plan.name}!`,
+      react: UpgradeEmail({
+        name: teamOwner.name,
+        email: teamOwner.email as string,
+        plan: plan.name,
+      })
+    });
+    log({
+      message: "Team " + `<${APP_DOMAIN}/${team.meta.slug}|${team.name}>` + " upgraded plan `free` to `" + plan.name + "` plan",
+      type: 'success',
+    })
+  } else {
+    log({
+      message: `Failed to update <${APP_DOMAIN}/${team.meta.slug}|${team.name}> team with subscription Id ${subscriptionId} ` + 'in Paddle webhook `subscription.activated` callback',
+      type: "errors",
+    })
+  }
+}

--- a/src/app/api/callback/paddle/subscription.canceled.ts
+++ b/src/app/api/callback/paddle/subscription.canceled.ts
@@ -1,0 +1,118 @@
+import { FREE_PLAN } from "@/lib/constants/pricing";
+import { TeamDbSchema } from "@/lib/db-schema";
+import { log } from "@/lib/functions/log";
+import { databaseName } from "@/lib/mongodb";
+import { MongoClient, ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+import { getTeamOwner } from "@/lib/api";
+import { sendEmailV2 } from "../../../../../emails";
+
+import { APP_DOMAIN } from "@/lib/constants";
+import { EventEntity, Subscription, SubscriptionNotification } from '@paddle/paddle-node-sdk';
+
+// Handled subscription.canceled event
+export async function subscriptionCanceled(event: EventEntity, client: MongoClient) {
+
+  const teamsCollection = client.db(databaseName).collection<TeamDbSchema>("teams");
+
+  const subscription = event.data as Subscription;
+
+  const subscriptionId = subscription.id;
+  const priceId = subscription.items[0].price?.id;
+  const customData = subscription.customData as Record<string, any>;
+  const teamId = customData?.teamId as string | undefined
+  const scheduledChange = subscription.scheduledChange;
+  const interval = subscription.items[0].price?.billingCycle?.interval;
+  const status = subscription.status;
+  const productId = subscription.items[0].price?.productId;
+  const nextBilledAt = subscription.nextBilledAt;
+  const pausedAt = subscription.pausedAt;
+  const canceledAt = subscription.canceledAt;
+
+  if (!subscriptionId || !teamId) {
+    await log({
+      message: `Missing subscriptionId:${subscriptionId} or teamId : ${subscriptionId} in Paddle webhook callback in Paddle webhook \`subscription.canceled\` callback`,
+      type: "errors",
+    });
+    return;
+  }
+
+  // If a team deletes their subscription, reset their usage limit in the database to 1000.
+  // Also remove the root domain redirect for all their domains from Redis.
+  console.log('\n 👉 Cancelling subscription for subscriptionId:', subscriptionId)
+  const team = await teamsCollection.findOne({ _id: new ObjectId(teamId) });
+  if (!team) {
+    await log({
+      message:
+        "Team with team ID *`" +
+        teamId +
+        "`* not found in Paddle webhook `subscription.canceled` callback",
+      type: "errors",
+    });
+    return;
+  }
+  console.log('\n 👉 Cancelling subscription for team:', team._id, team.meta.slug, team.plan, team.subscriptionId)
+  const teamOwner = await getTeamOwner(client, team._id.toString());
+  if (!teamOwner) {
+    await log({
+      message:
+        "Team with Subscription ID *`" +
+        subscriptionId +
+        "`* does not have an owner in Paddle webhook `subscription.canceled` callback",
+      type: "errors",
+    });
+    return NextResponse.json({ received: true });
+  }
+  console.log('\n 👉 Updating the database for team:', teamOwner.email)
+  await Promise.allSettled([
+    await teamsCollection.updateOne(
+      { subscriptionId: subscriptionId },
+      {
+        $set: {
+          plan: "free",
+          subscriptionId: undefined,
+          subscription: {
+            priceId: priceId!,
+            status: status,
+            id: subscriptionId,
+            productId: productId!,
+            canceledAt: canceledAt ? new Date(canceledAt!) : undefined,
+            nextBilledAt: nextBilledAt ? new Date(nextBilledAt!) : undefined,
+            pausedAt: pausedAt ? new Date(pausedAt!) : undefined,
+            interval: interval,
+            SubscriptionManagementUrls: subscription.managementUrls,
+            collectionMode: subscription.collectionMode,
+            scheduledChange: scheduledChange,
+            currentBillingPeriod: subscription.currentBillingPeriod
+          },
+          limit: {
+            pages: FREE_PLAN.limits.pages!,
+            users: FREE_PLAN.limits.users!,
+            workspaces: FREE_PLAN.limits.workspaces!,
+          }
+        },
+      },
+    ),
+
+    log({
+      message:
+        "Team *" +
+        `<${APP_DOMAIN}/${team.meta.slug}|${team.name}>` +
+        "* deleted their subscription",
+      type: 'alerts',
+      mention: true,
+    }),
+
+    sendEmailV2({
+      identifier: teamOwner!.email!,
+      subject: "Feedback on your Orgnise.in experience?",
+      text: `Hey!
+      I noticed you recently cancelled your Orgnise.in subscription - we're sorry to see you go!
+      I'd love to hear your feedback on your experience with Orgnise what could we have done better?
+      Thanks!
+      Sonu Sharma
+      Founder, Orgnise.in`,
+    }),
+
+  ]);
+}

--- a/src/app/api/callback/paddle/subscription.updated.ts
+++ b/src/app/api/callback/paddle/subscription.updated.ts
@@ -1,0 +1,88 @@
+import { APP_DOMAIN } from "@/lib/constants";
+import { getPlanFromPriceId } from "@/lib/constants/pricing";
+import { TeamDbSchema } from "@/lib/db-schema";
+import { log } from "@/lib/functions/log";
+import { collections } from "@/lib/mongodb";
+import { EventEntity, SubscriptionNotification } from '@paddle/paddle-node-sdk';
+import { MongoClient } from "mongodb";
+
+// Handle event "subscription.updated"
+export async function subscriptionUpdated(event: EventEntity, client: MongoClient) {
+
+  const teamsCollection = collections<TeamDbSchema>(client, "teams");
+  const subscription = event.data as SubscriptionNotification;
+  const subscriptionId = subscription.id;
+  const priceId = subscription.items[0].price?.id;
+  const scheduledChange = subscription.scheduledChange;
+  const interval = subscription.items[0].price?.billingCycle?.interval;
+  const status = subscription.status;
+  const productId = subscription.items[0].price?.productId;
+  const nextBilledAt = subscription.nextBilledAt;
+  const pausedAt = subscription.pausedAt;
+  const canceledAt = subscription.canceledAt;
+
+
+  const plan = getPlanFromPriceId(priceId!);
+
+  if (!plan) {
+    await log({
+      message: "Invalid price ID in `subscription.updated` event: " + priceId,
+      type: "errors",
+    });
+    return;
+  }
+
+
+
+  const team = await teamsCollection.findOne({ subscriptionId: subscriptionId }) as TeamDbSchema;
+  if (!team) {
+    await log({
+      message: "Team with  Subscription Id `" + subscriptionId + "` not found in Paddle webhook `subscription.updated` callback",
+      type: "errors",
+    });
+    return;
+  }
+
+  if (canceledAt || scheduledChange?.action === 'cancel') {
+    log({
+      message: ":cry: Team " + `<${APP_DOMAIN}/${team.meta.slug}|${team.name}>` + " has cancelled their `" + plan.name + "` subscription",
+    })
+    // Todo: Handle cancellation
+    return;
+  }
+
+  // If a team upgrades/downgrades their subscription, update their usage limit in the database.
+
+  const result = await teamsCollection.updateOne(
+    { subscriptionId: subscriptionId },
+    {
+      $set: {
+        plan: plan.name.toLowerCase() as any,
+        subscription: {
+          id: subscriptionId,
+          status: status,
+          priceId: priceId!,
+          productId: productId!,
+          scheduledChange: scheduledChange,
+          canceledAt: canceledAt ? new Date(canceledAt!) : undefined,
+          nextBilledAt: nextBilledAt ? new Date(nextBilledAt!) : undefined,
+          pausedAt: pausedAt ? new Date(pausedAt!) : undefined,
+          interval: interval,
+          collectionMode: subscription.collectionMode,
+          currentBillingPeriod: subscription.currentBillingPeriod
+        },
+        limit: {
+          pages: plan.limits.pages!,
+          users: plan.limits.users!,
+          workspaces: plan.limits.workspaces!,
+        }
+      },
+    },
+  );
+
+  log({
+    message: "Team " + `<${APP_DOMAIN}/${team.meta.slug}|${team.name}>` + " upgraded from `" + team.plan + "` to `" + plan.name + "` plan",
+    type: 'tada',
+  })
+
+}

--- a/src/app/api/callback/stripe/checkout-session-complete.ts
+++ b/src/app/api/callback/stripe/checkout-session-complete.ts
@@ -44,7 +44,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event, client: Mong
     return;
   }
 
-  const stripeId = checkoutSession.customer.toString();
+  const subscriptionId = checkoutSession.customer.toString();
 
   const team = await teamsCollection.findOne({ _id: new ObjectId(checkoutSession.client_reference_id) });
 
@@ -52,7 +52,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event, client: Mong
     await log({
       message:
         "Team with Stripe ID *`" +
-        stripeId +
+        subscriptionId +
         "`* not found in Stripe webhook `checkout.session.completed` callback",
       type: "errors",
     });
@@ -67,7 +67,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event, client: Mong
     { _id: team._id },
     {
       $set: {
-        stripeId,
+        subscriptionId,
         billingCycleStart: new Date().getDate(),
         plan: plan.name.toLowerCase() as any,
         limit: {
@@ -87,7 +87,7 @@ export async function checkoutSessionCompleted(event: Stripe.Event, client: Mong
       await log({
         message:
           "Team" + `<${APP_DOMAIN}/${team.meta.slug}|${team.name}>` + " with Stripe ID *`" +
-          stripeId +
+          subscriptionId +
           "`* does not have an owner in Stripe webhook `checkout.session.completed` callback",
         type: "errors",
       });

--- a/src/app/api/callback/stripe/customer-subscription-updated.ts
+++ b/src/app/api/callback/stripe/customer-subscription-updated.ts
@@ -27,12 +27,12 @@ export async function customerSubscriptionUpdated(event: Stripe.Event, client: M
     return;
   }
 
-  const stripeId = subscriptionUpdated.customer.toString();
+  const subscriptionId = subscriptionUpdated.customer.toString();
 
-  const team = await teamsCollection.findOne({ stripeId: stripeId }) as TeamDbSchema;
+  const team = await teamsCollection.findOne({ subscriptionId: subscriptionId }) as TeamDbSchema;
   if (!team) {
     await log({
-      message: "Team with  Stripe ID `" + stripeId + "` not found in Stripe webhook `customer.subscription.updated` callback",
+      message: "Team with  Stripe ID `" + subscriptionId + "` not found in Stripe webhook `customer.subscription.updated` callback",
       type: "errors",
     });
     return;
@@ -57,7 +57,7 @@ export async function customerSubscriptionUpdated(event: Stripe.Event, client: M
   // If a team upgrades/downgrades their subscription, update their usage limit in the database.
   else if (team.plan !== newPlan) {
     const result = await teamsCollection.updateOne(
-      { stripeId: stripeId },
+      { subscriptionId: subscriptionId },
       {
         $set: {
           plan: plan.name.toLowerCase() as any,

--- a/src/app/api/teams/[team_slug]/billing/cancel-subscription/route.ts
+++ b/src/app/api/teams/[team_slug]/billing/cancel-subscription/route.ts
@@ -1,0 +1,41 @@
+import { paddle } from "@/app/api/callback/paddle/route";
+import { withTeam } from "@/lib/auth";
+import { TeamDbSchema } from "@/lib/db-schema";
+import { collections } from "@/lib/mongodb";
+import { ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+
+// POST /api/teams/[team_slug]/billing/cancel-subscription - cancel paddle subscription
+export const POST = withTeam(async ({ team, client }) => {
+  if (!team.subscriptionId) {
+    return new Response("No paddle subscription ID available", { status: 400 });
+  }
+  try {
+    const subscriptionId = team.subscriptionId;
+    const res = await paddle.subscriptions.cancel(subscriptionId, { effectiveFrom: 'next_billing_period' });
+
+    const teams = collections<TeamDbSchema>(client, "teams");
+    const result = await teams.updateOne({ _id: new ObjectId(team._id) }, {
+      $set: {
+        subscription: {
+          priceId: res.items[0].price!.id,
+          id: subscriptionId,
+          status: res.status,
+          productId: res.items[0].price!.productId,
+          nextBilledAt: res.nextBilledAt ? new Date(res.nextBilledAt!) : undefined,
+          pausedAt: res.pausedAt ? new Date(res.pausedAt) : undefined,
+          SubscriptionManagementUrls: res.managementUrls,
+          collectionMode: res.collectionMode,
+          scheduledChange: res.scheduledChange,
+          interval: res.items[0].price!.billingCycle!.interval,
+          currentBillingPeriod: res.currentBillingPeriod
+        },
+        updatedAt: new Date()
+      }
+    });
+    console.log('result', result);
+    return NextResponse.json(res);
+  } catch (error: any) {
+    return NextResponse.json(error, { status: 400 });
+  }
+});

--- a/src/app/api/teams/[team_slug]/billing/manage/route.ts
+++ b/src/app/api/teams/[team_slug]/billing/manage/route.ts
@@ -5,11 +5,11 @@ import { NextResponse } from "next/server";
 
 // POST /api/teams/[team_slug]/billing/manage - create a Stripe billing portal session
 export const POST = withTeam(async ({ team }) => {
-  if (!team.stripeId) {
+  if (!team.subscriptionId) {
     return new Response("No Stripe customer ID", { status: 400 });
   }
   const { url } = await stripe.billingPortal.sessions.create({
-    customer: team.stripeId,
+    customer: team.subscriptionId,
     return_url: `${APP_DOMAIN}/${team.meta.slug}/settings/billing`,
   });
   return NextResponse.json(url);

--- a/src/app/api/teams/[team_slug]/billing/upgrade/route.ts
+++ b/src/app/api/teams/[team_slug]/billing/upgrade/route.ts
@@ -1,97 +1,24 @@
+import { paddle } from "@/app/api/callback/paddle/route";
 import { withTeam } from "@/lib/auth";
-import { APP_DOMAIN, COUNTRIES_SHORT_NAMES } from "@/lib/constants";
-import { stripe } from "@/lib/stripe";
 import { NextResponse } from "next/server";
 
-export const POST = withTeam(async ({ req, team, session }) => {
+export const POST = withTeam(async ({ req, team }) => {
   try {
-    let { plan, period, baseUrl, comparePlans } = await req.json();
+    let { priceId } = await req.json();
 
-    if (!plan || !period) {
-      return new Response("Invalid plan or period", { status: 400 });
+    if (!priceId || !team.subscriptionId) {
+      return new Response("Missing priceId or subscription ID", { status: 400 });
     }
 
-    plan = plan.replace(" ", "+");
+    const subscription = await paddle.subscriptions.update(team.subscriptionId!, {
+      items: [{ priceId: priceId, quantity: 1 }],
+      onPaymentFailure: 'prevent_change',
+      prorationBillingMode: 'prorated_immediately',
 
-    const prices = await stripe.prices.list({
-      lookup_keys: [`${plan}_${period}`],
     });
-    // console.log(prices);
-    if (!prices.data.length) {
-      return NextResponse.json(`Invalid plan or period: ${plan}_${period}`, { status: 400 });
-    }
 
-    const subscription = team.stripeId
-      ? await stripe.subscriptions.list({
-        customer: team.stripeId,
-        status: "active",
-      })
-      : null;
+    return NextResponse.json(subscription, { status: 200 });
 
-    console.log(`\n 👉 StripeId: ${team.stripeId}. Subscription: ${subscription?.data.length}. Plan: ${plan}_${period}`);
-
-    // if the user already has a subscription, create billing portal to upgrade
-    if (team.stripeId && subscription && subscription.data.length > 0) {
-      console.log("\n👉 User already has a subscription. Creating billing portal session");
-      console.log('\n', {
-        subscription: subscription.data[0].id,
-        items: [
-          {
-            id: subscription.data[0].items.data[0].id,
-            quantity: 1,
-            price: prices.data[0].id,
-          },
-        ],
-      })
-      console.log('\n ');
-      const { url } = await stripe.billingPortal.sessions.create({
-        customer: team.stripeId,
-        return_url: `${baseUrl}?upgrade=${plan}`,
-        flow_data: comparePlans
-          ? {
-            type: "subscription_update",
-            subscription_update: {
-              subscription: subscription.data[0].id,
-            },
-          }
-          : {
-            type: "subscription_update_confirm",
-            subscription_update_confirm: {
-              subscription: subscription.data[0].id,
-              items: [
-                {
-                  id: subscription.data[0].items.data[0].id,
-                  quantity: 1,
-                  price: prices.data[0].id,
-                },
-              ],
-            },
-          },
-      });
-
-      return NextResponse.json(url, { status: 200 });
-
-      // if the user does not have a subscription, create a new checkout session
-    } else {
-      const stripeSession = await stripe.checkout.sessions.create({
-        customer_email: session.user.email,
-        billing_address_collection: "required",
-        success_url: `${APP_DOMAIN}/${team.meta.slug}/settings/billing?success=true`,
-        cancel_url: `${baseUrl}?upgrade=${plan}`,
-        line_items: [{ price: prices.data[0].id, quantity: 1 }],
-        shipping_address_collection: {
-          allowed_countries: COUNTRIES_SHORT_NAMES as Array<any>
-        },
-        tax_id_collection: {
-          enabled: true,
-        },
-        mode: "subscription",
-        allow_promotion_codes: true,
-        client_reference_id: team._id.toString(),
-      });
-
-      return NextResponse.json(stripeSession);
-    }
   }
   catch (error) {
     console.log(error);

--- a/src/app/api/teams/[team_slug]/route.ts
+++ b/src/app/api/teams/[team_slug]/route.ts
@@ -95,7 +95,7 @@ export const DELETE = withTeam(
         await removeAllWorkspaces(client, team._id),
         await removeAllTeamUsers(client, team._id),
         await removeAllTeamInvites(client, team._id),
-        team.stripeId && cancelSubscription(team.stripeId),
+        team.subscriptionId && cancelSubscription(team.subscriptionId),
       ]);
 
 

--- a/src/components/ui/models/upgrade-plan-modal.tsx
+++ b/src/components/ui/models/upgrade-plan-modal.tsx
@@ -39,10 +39,12 @@ function UpgradePlanModal({
   showUpgradePlanModal,
   setShowUpgradePlanModal,
   PADDLE_SECRET_CLIENT_KEY,
+  PADDLE_ENV,
 }: {
   showUpgradePlanModal: boolean;
   setShowUpgradePlanModal: Dispatch<SetStateAction<boolean>>;
   PADDLE_SECRET_CLIENT_KEY?: string;
+  PADDLE_ENV: "sandbox" | "production";
 }) {
   const router = useRouter();
   const params = useParams() as { team_slug: string };
@@ -305,7 +307,7 @@ function UpgradePlanModal({
                     setClicked(false);
                   });
               } else {
-                console.log({ isStaging, paddle: process.env.PADDLE_ENV });
+                console.log({ isStaging });
                 const paddle = await getPaddle(
                   activeTeam!.meta!.slug!,
                   PADDLE_SECRET_CLIENT_KEY,
@@ -437,7 +439,10 @@ function UpgradePlanModal({
   );
 }
 
-export function useUpgradePlanModal(PADDLE_SECRET_CLIENT_KEY?: string) {
+export function useUpgradePlanModal(
+  PADDLE_SECRET_CLIENT_KEY?: string,
+  PADDLE_ENV: "sandbox" | "production" = "sandbox",
+) {
   const [showUpgradePlanModal, setShowUpgradePlanModal] = useState(false);
   const searchParams = useSearchParams();
   useEffect(() => {
@@ -454,9 +459,15 @@ export function useUpgradePlanModal(PADDLE_SECRET_CLIENT_KEY?: string) {
         showUpgradePlanModal={showUpgradePlanModal}
         setShowUpgradePlanModal={setShowUpgradePlanModal}
         PADDLE_SECRET_CLIENT_KEY={PADDLE_SECRET_CLIENT_KEY}
+        PADDLE_ENV={PADDLE_ENV}
       />
     );
-  }, [PADDLE_SECRET_CLIENT_KEY, showUpgradePlanModal, setShowUpgradePlanModal]);
+  }, [
+    PADDLE_ENV,
+    PADDLE_SECRET_CLIENT_KEY,
+    showUpgradePlanModal,
+    setShowUpgradePlanModal,
+  ]);
 
   return useMemo(
     () => ({

--- a/src/components/ui/models/upgrade-plan-modal.tsx
+++ b/src/components/ui/models/upgrade-plan-modal.tsx
@@ -1,18 +1,18 @@
-import { Badge, Button2, LoadingSpinner, Modal } from "@/components/ui/";
-import { getStripe } from "@/lib/stripe/client";
-
 import { IconMenu } from "@/components/atom/icon-menu";
 import { Logo } from "@/components/atom/logo";
+import { Badge, Button2, LoadingSpinner, Modal } from "@/components/ui/";
 import { APP_DOMAIN } from "@/lib/constants/constants";
 import { STAGGER_CHILD_VARIANTS } from "@/lib/constants/framer-motion";
 import { SELF_SERVE_PAID_PLANS } from "@/lib/constants/pricing";
 import { capitalize } from "@/lib/functions/capitalize";
 import { useRouterStuff } from "@/lib/hooks";
+import { getPaddle } from "@/lib/paddle/paddle-client";
 import useTeam from "@/lib/swr/use-team";
 import { Plan } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { Check, ChevronDown } from "lucide-react";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import {
   useParams,
@@ -29,6 +29,7 @@ import {
   useState,
 } from "react";
 import Confetti from "react-dom-confetti";
+import { toast } from "sonner";
 import CheckCircleFill from "../icons/check-circle-fill";
 import { Popover2 } from "../popover-2";
 
@@ -37,9 +38,11 @@ const PERIODS = ["monthly", "yearly"] as const;
 function UpgradePlanModal({
   showUpgradePlanModal,
   setShowUpgradePlanModal,
+  PADDLE_SECRET_CLIENT_KEY,
 }: {
   showUpgradePlanModal: boolean;
   setShowUpgradePlanModal: Dispatch<SetStateAction<boolean>>;
+  PADDLE_SECRET_CLIENT_KEY?: string;
 }) {
   const router = useRouter();
   const params = useParams() as { team_slug: string };
@@ -48,7 +51,9 @@ function UpgradePlanModal({
   const welcomeFlow = pathname === "/welcome";
   const slug = welcomeFlow ? searchParams?.get("team_slug") : params.team_slug;
 
-  const { activeTeam } = useTeam();
+  const { data: session, status } = useSession();
+  const user = session?.user;
+  const { activeTeam, mutate } = useTeam();
   const { plan: currentPlan } = activeTeam!;
   const plan = (searchParams.get("upgrade") ?? "pro") as Plan;
   const selectedPlan =
@@ -260,44 +265,84 @@ function UpgradePlanModal({
           <Button2
             text={`Upgrade to ${selectedPlan.name} ${capitalize(period)}`}
             loading={clicked}
-            onClick={() => {
+            onClick={async () => {
               setClicked(true);
-              fetch(`/api/teams/${slug}/billing/upgrade`, {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  plan,
-                  period,
-                  baseUrl: `${APP_DOMAIN}${pathname}`,
-                }),
-              })
-                .then(async (res) => {
-                  if (res.status === 200) {
-                    if (currentPlan === "free") {
-                      const data = await res.json();
-                      const { id: sessionId } = data;
-                      const stripe = await getStripe();
-                      stripe?.redirectToCheckout({ sessionId });
+              if (activeTeam?.subscriptionId) {
+                fetch(`/api/teams/${slug}/billing/upgrade`, {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({
+                    priceId:
+                      selectedPlan.price.ids[period === "monthly" ? 0 : 1],
+                  }),
+                })
+                  .then(async (res) => {
+                    if (res.status === 200) {
+                      if (currentPlan === "free") {
+                        const data = await res.json();
+                        console.log(data);
+                        toast.success("Upgrade success!");
+                        await mutate();
+                      }
                     } else {
                       const url = await res.json();
                       router.push(url);
                     }
-                  } else {
-                    console.error(res);
+                  })
+                  .catch((err) => {
+                    alert(err);
                     setClicked(false);
+                  });
+              } else {
+                const paddle = await getPaddle(
+                  activeTeam!.meta!.slug!,
+                  PADDLE_SECRET_CLIENT_KEY,
+                );
+                if (paddle) {
+                  try {
+                    setTimeout(() => {
+                      setShowUpgradePlanModal(false);
+                    }, 1000);
+                    paddle?.Checkout.open({
+                      items: [
+                        {
+                          priceId:
+                            selectedPlan.price.ids[
+                              period === "monthly" ? 0 : 1
+                            ],
+                          quantity: 1,
+                        },
+                      ],
+                      customData: {
+                        teamId: activeTeam!._id ?? "",
+                        team: activeTeam!.name ?? "",
+                        url: `${APP_DOMAIN}/${activeTeam!.meta!.slug!}`,
+                      },
+                      customer: {
+                        // id: user?.id ?? "",
+                        // id: user?.id ?? "",
+                        // @ts-ignore
+                        email: user!.email ?? "",
+                        business: {
+                          id: activeTeam!._id ?? "",
+                          // @ts-ignore
+                          // name: activeTeam!.name ?? "",
+                        },
+                      },
+                    });
+                  } catch (error) {
+                    setClicked(false);
+                    console.error(error);
                   }
-                })
-                .catch((err) => {
-                  alert(err);
-                  setClicked(false);
-                });
+                }
+              }
             }}
           />
 
           <div className="mt-2 flex items-center justify-center space-x-2">
-            {currentPlan === "free" ? (
+            {true ? (
               <a
                 href="https://orgnise.in/pricing"
                 target="_blank"
@@ -373,7 +418,7 @@ function UpgradePlanModal({
   );
 }
 
-export function useUpgradePlanModal() {
+export function useUpgradePlanModal(PADDLE_SECRET_CLIENT_KEY?: string) {
   const [showUpgradePlanModal, setShowUpgradePlanModal] = useState(false);
   const searchParams = useSearchParams();
   useEffect(() => {
@@ -389,9 +434,10 @@ export function useUpgradePlanModal() {
       <UpgradePlanModal
         showUpgradePlanModal={showUpgradePlanModal}
         setShowUpgradePlanModal={setShowUpgradePlanModal}
+        PADDLE_SECRET_CLIENT_KEY={PADDLE_SECRET_CLIENT_KEY}
       />
     );
-  }, [showUpgradePlanModal, setShowUpgradePlanModal]);
+  }, [PADDLE_SECRET_CLIENT_KEY, showUpgradePlanModal, setShowUpgradePlanModal]);
 
   return useMemo(
     () => ({

--- a/src/lib/api/team.ts
+++ b/src/lib/api/team.ts
@@ -56,7 +56,10 @@ export async function fetchDecoratedTeam(client: MongoClient, teamId: string, us
           inviteCode: "$team.inviteCode",
           logo: "$team.logo",
           limit: "$team.limit",
-          stripeId: "$team.stripeId",
+          subscriptionId: "$team.subscriptionId",
+          scheduledChange: "$team.subscription.scheduledChange",
+          interval: "$team.subscription.interval",
+          currentBillingPeriod: "$team.subscription.currentBillingPeriod"
         },
       },
       // Remove team object from root object
@@ -88,7 +91,10 @@ export async function fetchDecoratedTeam(client: MongoClient, teamId: string, us
     })
     return {
       ...team,
-      stripeId: teamList[0].stripeId,
+      billingInterval: teamList[0].interval,
+      subscriptionId: teamList[0].subscriptionId,
+      scheduledChange: teamList[0].scheduledChange,
+      currentBillingPeriod: teamList[0].currentBillingPeriod
     };
   }
   return undefined;
@@ -151,7 +157,8 @@ export async function fetchAllTeamOwnedByUser(client: MongoClient, userId: strin
           inviteCode: "$team.inviteCode",
           limit: "$team.limit",
           logo: "$team.logo",
-          stripeId: "$team.stripeId",
+          subscriptionId: "$team.subscriptionId",
+          scheduledChange: "$team.subscription.scheduledChange",
         },
       },
       // Remove team object from root object

--- a/src/lib/constants/pricing.ts
+++ b/src/lib/constants/pricing.ts
@@ -101,8 +101,10 @@ export const PLANS = [
       monthly: 24,
       yearly: 19,
       ids: [
-        'price_1PH267SHsqzoawbHfT36lPoJ',
-        'price_1PH267SHsqzoawbHcYuCeSlZ'
+        'pri_01j0tq0tb7g3e8mwe0rfgr43r2',
+        'pri_01j11nqqw758hpfkkdkp5ejngz'
+        // 'price_1PH267SHsqzoawbHfT36lPoJ',
+        // 'price_1PH267SHsqzoawbHcYuCeSlZ'
       ] as string[],
     },
     limits: {
@@ -135,15 +137,17 @@ export const PLANS = [
     pages: 600,
     workspaces: 30,
     ids: [
-      'price_1PH29GSHsqzoawbHsqk5dD3y',
-      'price_1PH29GSHsqzoawbHTTQ1WGbb'
+      'pri_01j11p1sga7scd3tn59pv8zzq6',
+      'pri_01j11pf34t068ntj7533t35sad'
+      // 'price_1PH29GSHsqzoawbHsqk5dD3y',
+      // 'price_1PH29GSHsqzoawbHTTQ1WGbb'
     ]
   }),
   ,
   {
     name: "Enterprise",
     tagline:
-      "Custom tailored plans for large enterprises. Whether you're running a SMS campaign with millions of short links or a large marketing campaign with billions of clicks, we've got you covered.",
+      "Tailored plans for large corporations are available. Whether you are managing a multinational company or a local business, it is important to have a plan that fits your specific needs and goals. Our team of experts will work with you to create a customized strategy that maximizes efficiency and drives success in your industry",
     link: "https://organise.in/enterprise",
     price: {
       monthly: null,

--- a/src/lib/constants/pricing.ts
+++ b/src/lib/constants/pricing.ts
@@ -101,10 +101,10 @@ export const PLANS = [
       monthly: 24,
       yearly: 19,
       ids: [
-        'pri_01j0tq0tb7g3e8mwe0rfgr43r2',
-        'pri_01j11nqqw758hpfkkdkp5ejngz'
-        // 'price_1PH267SHsqzoawbHfT36lPoJ',
-        // 'price_1PH267SHsqzoawbHcYuCeSlZ'
+        'pri_01j1d2wt5755sy0891nwev4jbs', // Monthly
+        'pri_01j1d34bwgh6c3fx33hq0kbat6', // Yearly
+        'pri_01j0tq0tb7g3e8mwe0rfgr43r2', // Monthly
+        'pri_01j11nqqw758hpfkkdkp5ejngz' // Yearly
       ] as string[],
     },
     limits: {
@@ -137,10 +137,10 @@ export const PLANS = [
     pages: 600,
     workspaces: 30,
     ids: [
-      'pri_01j11p1sga7scd3tn59pv8zzq6',
-      'pri_01j11pf34t068ntj7533t35sad'
-      // 'price_1PH29GSHsqzoawbHsqk5dD3y',
-      // 'price_1PH29GSHsqzoawbHTTQ1WGbb'
+      'pri_01j1d383r3rynxr3v5k9w1t7j9',// Monthly
+      'pri_01j1d39wx7x4kxadhmnmy30x3t',// Yearly
+      'pri_01j11p1sga7scd3tn59pv8zzq6',// Monthly
+      'pri_01j11pf34t068ntj7533t35sad'// Yearly
     ]
   }),
   ,

--- a/src/lib/db-schema/team.schema.ts
+++ b/src/lib/db-schema/team.schema.ts
@@ -4,6 +4,7 @@ import { ObjectId } from "mongodb";
 import { Plan } from "../types/types";
 import { LimitSchema } from "../zod/schemas";
 import z from "../zod";
+import { CollectionMode, Interval, SubscriptionManagement, SubscriptionScheduledChangeNotification, SubscriptionStatus, SubscriptionTimePeriodNotification } from "@paddle/paddle-node-sdk";
 
 export interface TeamDbSchema {
   _id: ObjectId;
@@ -11,13 +12,14 @@ export interface TeamDbSchema {
   description?: string;
   createdBy: ObjectId;
   plan: Plan;
-  stripeId?: string;
+  subscriptionId?: string;
   meta: MetaSchema;
   createdAt: Date;
   billingCycleStart: number;
   inviteCode: string;
   logo: string;
   updatedAt: Date;
+  subscription: Subscription;
   limit: z.infer<typeof LimitSchema>;
 }
 
@@ -38,3 +40,20 @@ export interface TeamMemberDbSchema {
 export interface TeamInviteDbSchema extends Omit<TeamMemberDbSchema, 'updatedAt' | 'user'> {
   expires: Date
 }
+
+
+export interface Subscription {
+  id: string;
+  priceId: string;
+  status: SubscriptionStatus;
+  productId: string;
+  canceledAt?: Date | null;
+  scheduledChange?: SubscriptionScheduledChangeNotification | null;
+  nextBilledAt?: Date | null;
+  pausedAt?: Date | null;
+  interval?: Interval;
+  SubscriptionManagementUrls?: SubscriptionManagement | null;
+  collectionMode?: CollectionMode;
+  currentBillingPeriod: SubscriptionTimePeriodNotification | null;
+}
+

--- a/src/lib/functions/log.ts
+++ b/src/lib/functions/log.ts
@@ -54,7 +54,7 @@ export const log = async ({
             text: {
               type: "mrkdwn",
               // prettier-ignore
-              text: `${mention ? "<#D06Q02G3Y9L> " : ""}${switchType(type)}${message}`,
+              text: `${switchType(type)}${message}`,
             },
           },
         ],

--- a/src/lib/paddle/paddle-client.ts
+++ b/src/lib/paddle/paddle-client.ts
@@ -1,0 +1,32 @@
+import { initializePaddle, Paddle, } from '@paddle/paddle-js';
+import { APP_DOMAIN } from '../constants';
+
+
+let paddlePromise: Promise<Paddle | undefined>;
+
+export async function getPaddle(slug: string, PADDLE_SECRET_CLIENT_KEY?: string) {
+  if (!PADDLE_SECRET_CLIENT_KEY) {
+    throw new Error("Paddle secret key is missing")
+  }
+  if (!paddlePromise) {
+    paddlePromise = initializePaddle({
+      environment: process.env.PADDLE_ENV === 'production' ? 'production' : 'sandbox',
+      token: PADDLE_SECRET_CLIENT_KEY ?? "",
+      checkout: {
+        settings: {
+          successUrl: `${APP_DOMAIN}/${slug}/settings/billing?success=true`,
+          displayMode: 'overlay',
+          showAddTaxId: true,
+          theme: 'light',
+        },
+      },
+      debug: true,
+      eventCallback(event) {
+        console.log(event);
+      },
+
+    })
+  }
+
+  return paddlePromise;
+};

--- a/src/lib/paddle/paddle-client.ts
+++ b/src/lib/paddle/paddle-client.ts
@@ -4,13 +4,13 @@ import { APP_DOMAIN } from '../constants';
 
 let paddlePromise: Promise<Paddle | undefined>;
 
-export async function getPaddle(slug: string, PADDLE_SECRET_CLIENT_KEY?: string) {
+export async function getPaddle(slug: string, PADDLE_SECRET_CLIENT_KEY?: string, PADDLE_ENV: string = 'sandbox') {
   if (!PADDLE_SECRET_CLIENT_KEY) {
     throw new Error("Paddle secret key is missing")
   }
   if (!paddlePromise) {
     paddlePromise = initializePaddle({
-      environment: process.env.PADDLE_ENV === 'production' ? 'production' : 'sandbox',
+      environment: PADDLE_ENV as any,//process.env.PADDLE_ENV === 'production' ? 'production' : 'sandbox',
       token: PADDLE_SECRET_CLIENT_KEY ?? "",
       checkout: {
         settings: {

--- a/src/lib/paddle/paddle-client.ts
+++ b/src/lib/paddle/paddle-client.ts
@@ -22,7 +22,7 @@ export async function getPaddle(slug: string, PADDLE_SECRET_CLIENT_KEY?: string)
       },
       debug: true,
       eventCallback(event) {
-        console.log(event);
+        // console.log(event);
       },
 
     })

--- a/src/lib/types/types.ts
+++ b/src/lib/types/types.ts
@@ -2,9 +2,13 @@ import { TeamRole } from "@/lib/constants/team-role";
 import { WorkspaceRole } from "@/lib/constants/workspace-role";
 import { TeamSchema } from "@/lib/zod/schemas";
 import z from "../zod";
+import { Interval, SubscriptionScheduledChangeNotification, SubscriptionTimePeriodNotification } from "@paddle/paddle-node-sdk";
 
 export interface Team extends z.infer<typeof TeamSchema> {
-  stripeId?: string;
+  subscriptionId?: string;
+  billingInterval?: Interval;
+  currentBillingPeriod?: SubscriptionTimePeriodNotification;
+  scheduledChange?: SubscriptionScheduledChangeNotification;
 }
 
 export interface Member {

--- a/src/lib/utility/datetime.ts
+++ b/src/lib/utility/datetime.ts
@@ -21,6 +21,47 @@ export const getFirstAndLastDay = (day: number) => {
     };
   }
 };
+
+export const getFirstAndLastDay2 = (day: number, interval: "month" | "year") => {
+  const today = new Date();
+  const currentDay = today.getDate();
+  const currentMonth = today.getMonth();
+  const currentYear = today.getFullYear();
+
+  if (interval === "month") {
+    if (currentDay >= day) {
+      // if the current day is greater than target day, it means that we just passed it
+      return {
+        firstDay: new Date(currentYear, currentMonth, day),
+        lastDay: new Date(currentYear, currentMonth + 1, day - 1),
+      };
+    } else {
+      // if the current day is less than target day, it means that we haven't passed it yet
+      const lastMonth = currentMonth === 0 ? 11 : currentMonth - 1;
+      return {
+        firstDay: new Date(currentYear, lastMonth, day),
+        lastDay: new Date(currentYear, currentMonth, day - 1),
+      };
+    }
+  } else if (interval === "year") {
+    if (currentDay >= day) {
+      // if the current day is greater than target day, it means that we just passed it
+      return {
+        firstDay: new Date(currentYear, currentMonth, day),
+        lastDay: new Date(currentYear + 1, currentMonth, day - 1),
+      };
+    } else {
+      // if the current day is less than target day, it means that we haven't passed it yet
+      const lastYear = currentYear - 1;
+      return {
+        firstDay: new Date(lastYear, currentMonth, day),
+        lastDay: new Date(currentYear, currentMonth, day - 1),
+      };
+    }
+  } else {
+    throw new Error("Invalid interval. It must be either 'month' or 'year'.");
+  }
+};
 /**
  * Returns a string representing the time elapsed since the given timestamp.
  * @param timestamp - The timestamp to compare to the current time.


### PR DESCRIPTION
## Summary
This PR integrates Paddle as a new payment gateway, replaces Stripe checkout with Paddle, and removes Stripe subscription management. Additionally, it handles checkout for production and staging environments and adds a Contact Us link to upgrade plans.

## Changelog

* **New Feature:** Integrated Paddle as a payment gateway
* **Update:** Replaced Stripe checkout with Paddle
* **Removal:** Removed manage Stripe subscription feature
* **Fix:** Handled checkout for production and staging environments
* **Update:** Added contact us link to upgrade plan