### PR TITLE
Add Page/Collection Drag and Drop in Board View + Reorder/Move API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,12 @@
       "name": "orgnise",
       "version": "0.1.0",
       "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.2.1",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^1.4.0",
+        "@atlaskit/pragmatic-drag-and-drop-flourish": "^1.1.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+        "@atlaskit/primitives": "^11.0.1",
+        "@atlaskit/tokens": "^1.55.0",
         "@auth/core": "^0.19.0",
         "@auth/mongodb-adapter": "^2.0.10",
         "@paddle/paddle-js": "^1.2.0",
@@ -98,6 +104,196 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@atlaskit/app-provider": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/app-provider/-/app-provider-1.3.3.tgz",
+      "integrity": "sha512-xtRJcKlFg2uLYQsd2fQgv2kukHu2YzhkqCXDXqLvl5W9Plbm69dqiAeenN1tyBULrU7OJqVhyghxajpzj1Uzvg==",
+      "dependencies": {
+        "@atlaskit/tokens": "^1.50.0",
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ~18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/css": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/css/-/css-0.3.0.tgz",
+      "integrity": "sha512-vzkguj9fKF9HkyO8wmfCUL8ZgOs6rTqvZHC0bQtjAVRHWicScnZY3Rj0IyUTo/qlsVI5aFHcByloM/izjUYnmA==",
+      "dependencies": {
+        "@atlaskit/tokens": "^1.51.0",
+        "@babel/runtime": "^7.0.0",
+        "@compiled/react": "^0.17.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ~18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/ds-lib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/ds-lib/-/ds-lib-2.3.1.tgz",
+      "integrity": "sha512-DVUE3hYLhdEZy4NnsxqiCqKC5Ym3CM/DGRQlnSPcABFNL0N0FfTXso3pLpkJnMZBtEnd2pn13mPJ2VQlSISRuw==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ~18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/motion": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@atlaskit/motion/-/motion-1.7.4.tgz",
+      "integrity": "sha512-Kwi1RAMzUSypjmWEqyGopZUHTrdMOJNMriMxmUHnMDZ+dMwRfZJ7ZH6EpOnLjnH/CcN6zK0+fzm5E0Rlo5mBzg==",
+      "dependencies": {
+        "@atlaskit/ds-lib": "^2.3.0",
+        "@atlaskit/platform-feature-flags": "^0.3.0",
+        "@babel/runtime": "^7.0.0",
+        "@emotion/react": "^11.7.1",
+        "bind-event-listener": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ~18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/platform-feature-flags": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz",
+      "integrity": "sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.2.1.tgz",
+      "integrity": "sha512-gW2wJblFAeg94YXITHg0YdhFM2nmFAdDmX0LKYBIm79yEbIrOiuHHukgSjII07M4U5JpJ0Ff/4BaADjN23ix+A==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-auto-scroll": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-auto-scroll/-/pragmatic-drag-and-drop-auto-scroll-1.4.0.tgz",
+      "integrity": "sha512-5GoikoTSW13UX76F9TDeWB8x3jbbGlp/Y+3aRkHe1MOBMkrWkwNpJ42MIVhhX/6NSeaZiPumP0KbGJVs2tOWSQ==",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.2.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-flourish": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-flourish/-/pragmatic-drag-and-drop-flourish-1.1.0.tgz",
+      "integrity": "sha512-JVyrGh4Yc14U99MPWYIwjgo3ODSlGtXH9IIKxm4Nbac8N56sqBO+2YfKPxBjpmC3i+Dn9uUzpNNxNHVJpdP9Kw==",
+      "dependencies": {
+        "@atlaskit/motion": "^1.5.0",
+        "@atlaskit/tokens": "^1.43.0",
+        "@babel/runtime": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.0.3.tgz",
+      "integrity": "sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.1.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/primitives": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-11.0.1.tgz",
+      "integrity": "sha512-tIrqe5EuhJfbnQwdzyFhHmkvxOZf68yw2G+puOsmKorBEfM6+oGGqbIoSxRAxGloJ2XizZJaJeabHoiCqgv9Cg==",
+      "dependencies": {
+        "@atlaskit/analytics-next": "^9.3.0",
+        "@atlaskit/app-provider": "^1.3.0",
+        "@atlaskit/css": "^0.3.0",
+        "@atlaskit/ds-lib": "^2.3.0",
+        "@atlaskit/interaction-context": "^2.1.0",
+        "@atlaskit/tokens": "^1.54.0",
+        "@atlaskit/visually-hidden": "^1.4.0",
+        "@babel/runtime": "^7.0.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.1.0",
+        "bind-event-listener": "^3.0.0",
+        "react-uid": "^2.2.0",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@atlaskit/primitives/node_modules/@atlaskit/analytics-next": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next/-/analytics-next-9.3.1.tgz",
+      "integrity": "sha512-aG+IWWS4J/sNxRdZ//WQ+0GxDe1diUxAFszqwQZXOcSXzxIuVYpgdBy+Cr5g4vLVp1XExwUu+gQ7lVzHHPXcWA==",
+      "dependencies": {
+        "@atlaskit/analytics-next-stable-react-context": "1.0.1",
+        "@atlaskit/platform-feature-flags": "^0.3.0",
+        "@babel/runtime": "^7.0.0",
+        "prop-types": "^15.5.10",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0"
+      }
+    },
+    "node_modules/@atlaskit/primitives/node_modules/@atlaskit/analytics-next/node_modules/@atlaskit/analytics-next-stable-react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/analytics-next-stable-react-context/-/analytics-next-stable-react-context-1.0.1.tgz",
+      "integrity": "sha512-iO6+hIp09dF4iAZQarVz3vKY1kM5Ij5CExYcK9jgc2q+OH8nv8n+BPFeJTdzGOGopmbUZn5Opj9pYQvge1Gr4Q==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0"
+      }
+    },
+    "node_modules/@atlaskit/primitives/node_modules/@atlaskit/interaction-context": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@atlaskit/interaction-context/-/interaction-context-2.1.4.tgz",
+      "integrity": "sha512-MTuHN8wLYBPADE83Q+9KF5BcKyMW9/FkmA+lB/XnHwYIL86sMPzMSTM0DPG7crq/JI0JM0jlyY3Xzz0Aba7G+A==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0"
+      }
+    },
+    "node_modules/@atlaskit/tokens": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-1.55.0.tgz",
+      "integrity": "sha512-h9pOIZezo1cP6doW1wtpo/NkUoEznUIHufOBvhLRdmwfGe/w9qlGeewvdF3o6Se4gsPO/Yn7WHy6Bhom+LdKgg==",
+      "dependencies": {
+        "@atlaskit/ds-lib": "^2.3.0",
+        "@atlaskit/platform-feature-flags": "^0.3.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.20.0",
+        "bind-event-listener": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ~18.2.0"
+      }
+    },
+    "node_modules/@atlaskit/visually-hidden": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/visually-hidden/-/visually-hidden-1.4.1.tgz",
+      "integrity": "sha512-U8knuHnTLbjtPCQRA97Mq0g+DA69JcB5FmjIM4C4CMhS33MDCB6uuWdD9fnuLVvy9qyIPkOGf1QPF/Pw+w8cEw==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@emotion/react": "^11.7.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ~18.2.0"
+      }
+    },
     "node_modules/@auth/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.19.1.tgz",
@@ -162,31 +358,110 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/generator": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.8.tgz",
+      "integrity": "sha512-47DG+6F5SzOi0uEvK4wMShmn5yY0mVjVJoWTphdY2B4Rx9wHgjK7Yhtr0ru6nE+sn0v38mzrWOlah0p/YlHHOQ==",
+      "dependencies": {
+        "@babel/types": "^7.24.8",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "dependencies": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "dependencies": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -259,6 +534,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
@@ -270,12 +556,77 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/template": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "dependencies": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
+      "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+      "dependencies": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.8",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-hoist-variables": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/parser": "^7.24.8",
+        "@babel/types": "^7.24.8",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.8.tgz",
+      "integrity": "sha512-SkSBEHwwJRU52QEVZBmMBnE5Ux2/6WU1grdYyOhpbCNxbmJrDuDCphBzKZSO3taf0zztp+qkWlymE5tVL5l0TA==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@cfcs/core": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@cfcs/core/-/core-0.0.6.tgz",
       "integrity": "sha512-FxfJMwoLB8MEMConeXUCqtMGqxdtePQxRBOiGip9ULcYYam3WfCgoY6xdnMaSkYvRvmosp5iuG+TiPofm65+Pw==",
       "dependencies": {
         "@egjs/component": "^3.0.2"
+      }
+    },
+    "node_modules/@compiled/react": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@compiled/react/-/react-0.17.2.tgz",
+      "integrity": "sha512-/HA19vIqMnfM6sz1mwqdYABae2oocJ1xoWR87zU7oyH6uk6+L58hlhloQy5GJ5BtdWZl+50DLAFY53GVecD8VA==",
+      "dependencies": {
+        "csstype": "^3.1.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.12.0"
       }
     },
     "node_modules/@daybrush/utils": {
@@ -306,6 +657,70 @@
       "resolved": "https://registry.npmjs.org/@egjs/list-differ/-/list-differ-1.0.1.tgz",
       "integrity": "sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg=="
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -320,6 +735,74 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
+      "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
+      "integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.11",
@@ -3269,6 +3752,11 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+    },
     "node_modules/@types/prismjs": {
       "version": "1.26.3",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.3.tgz",
@@ -4038,6 +4526,20 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -4102,6 +4604,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q=="
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -4750,6 +5257,11 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
     "node_modules/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -4768,6 +5280,29 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/crelt": {
@@ -6052,6 +6587,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -7344,6 +7884,17 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/json-buffer": {
@@ -9132,7 +9683,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10733,6 +11283,26 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-uid": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.3.3.tgz",
+      "integrity": "sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -11684,6 +12254,11 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -12012,6 +12587,14 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.3"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
     "script": "tsx ./scripts/run.ts"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.2.1",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^1.4.0",
+    "@atlaskit/pragmatic-drag-and-drop-flourish": "^1.1.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
+    "@atlaskit/primitives": "^11.0.1",
+    "@atlaskit/tokens": "^1.55.0",
     "@auth/core": "^0.19.0",
     "@auth/mongodb-adapter": "^2.0.10",
     "@paddle/paddle-js": "^1.2.0",

--- a/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/[item_slug]/page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/[item_slug]/page-client.tsx
@@ -56,7 +56,7 @@ export default function ItemPageClient() {
   );
 
   const onKeyDown = (e: any) => {
-    if (e.metaKey && e.which === 83) {
+    if ((e.metaKey && e.which === 83) || (e.ctrlKey && e.key === "s")) {
       e.preventDefault();
       UpdateActiveItem(
         {

--- a/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/[item_slug]/page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/[item_slug]/page-client.tsx
@@ -177,7 +177,7 @@ function CollectionNameField({
 }) {
   return (
     <form
-      className="group flex flex-grow items-center rounded border  border-transparent focus-within:border-border "
+      className="group flex flex-grow items-center"
       onSubmit={(e: any) => {
         e.preventDefault();
         const value = e.target.name.value;

--- a/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/page-client.tsx
@@ -192,7 +192,7 @@ function CollectionNameField({
         autoFocus
         disabled={disabled}
         className="flex-grow border-none bg-transparent  text-2xl font-bold placeholder:text-2xl placeholder:text-muted-foreground placeholder:opacity-50 focus-visible:outline-none focus-visible:ring-0"
-        maxLength={70}
+        maxLength={32}
         defaultValue={name}
         required
         name="name"

--- a/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/page-client.tsx
@@ -79,31 +79,6 @@ export default function CollectionContentPageClient() {
               );
             }}
           />
-          {activeCollection!.children.length > 0 && (
-            <WorkspacePermissionView permission="CREATE_CONTENT">
-              <UsageLimitView
-                exceedingLimit={exceedingPageLimit}
-                upgradeMessage={`Current plan can have upto ${limit?.pages} pages in all workspaces. For higher pages quota upgrade to ${getNextPlan(plan)?.name} plan.`}
-                plan={plan}
-                team_slug={meta?.slug}
-                placeholder={
-                  <Button size={"sm"} variant={"subtle"}>
-                    Create Page
-                  </Button>
-                }
-              >
-                <Button
-                  variant={"default"}
-                  className="border-dotted  border-muted-foreground "
-                  size={"sm"}
-                >
-                  <CreateItemCTA activeCollection={activeCollection!}>
-                    &nbsp; Create Page
-                  </CreateItemCTA>
-                </Button>
-              </UsageLimitView>
-            </WorkspacePermissionView>
-          )}
         </div>
         <ListView
           items={activeCollection!.children}
@@ -116,7 +91,32 @@ export default function CollectionContentPageClient() {
               collection={activeCollection}
             />
           )}
-          footerElement={<div className="w-full"></div>}
+          footerElement={
+            activeCollection!.children.length > 0 && (
+              <WorkspacePermissionView permission="CREATE_CONTENT">
+                <UsageLimitView
+                  exceedingLimit={exceedingPageLimit}
+                  upgradeMessage={`Current plan can have upto ${limit?.pages} pages in all workspaces. For higher pages quota upgrade to ${getNextPlan(plan)?.name} plan.`}
+                  plan={plan}
+                  team_slug={meta?.slug}
+                  placeholder={
+                    <Button size={"sm"} variant={"subtle"}>
+                      Create Page
+                    </Button>
+                  }
+                >
+                  <Button
+                    className="my-4 w-full border border-dashed p-4"
+                    variant={"ghost"}
+                  >
+                    <CreateItemCTA activeCollection={activeCollection!}>
+                      &nbsp; Create Page
+                    </CreateItemCTA>
+                  </Button>
+                </UsageLimitView>
+              </WorkspacePermissionView>
+            )
+          }
           noItemsElement={<NoItemsView activeCollection={activeCollection} />}
         />
       </div>
@@ -178,7 +178,7 @@ function CollectionNameField({
 }) {
   return (
     <form
-      className="group mr-4 flex flex-grow items-center rounded  border border-transparent focus-within:border-border"
+      className="group mr-4 flex flex-grow items-center rounded   border-transparent focus-within:border-border"
       onSubmit={(e: any) => {
         e.preventDefault();
         const value = e.target.name.value;

--- a/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/page-client.tsx
+++ b/src/app/(dashboard)/[team_slug]/[workspace_slug]/[collection_slug]/page-client.tsx
@@ -82,6 +82,7 @@ export default function CollectionContentPageClient() {
         </div>
         <ListView
           items={activeCollection!.children}
+          sortBy={(a: Collection, b: Collection) => a.sortIndex - b.sortIndex}
           className="flex flex-col  overflow-y-auto pb-28 pt-4"
           renderItem={(item, index) => (
             <CollectionItemCard
@@ -109,7 +110,10 @@ export default function CollectionContentPageClient() {
                     className="my-4 w-full border border-dashed p-4"
                     variant={"ghost"}
                   >
-                    <CreateItemCTA activeCollection={activeCollection!}>
+                    <CreateItemCTA
+                      activeCollection={activeCollection!}
+                      className="w-full place-content-center"
+                    >
                       &nbsp; Create Page
                     </CreateItemCTA>
                   </Button>

--- a/src/app/api/teams/[team_slug]/[workspace_slug]/collections/reorder/route.ts
+++ b/src/app/api/teams/[team_slug]/[workspace_slug]/collections/reorder/route.ts
@@ -1,0 +1,136 @@
+import { OrgniseApiError, handleAndReturnErrorResponse } from "@/lib/api";
+import { withWorkspace } from "@/lib/auth";
+import { CollectionDbSchema } from "@/lib/db-schema";
+import { collections } from "@/lib/mongodb";
+import { Collection } from "@/lib/types/types";
+import { reorderCollectionSchema } from "@/lib/zod/schemas";
+import { ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+
+// POST /api/teams/:team_slug/:workspace_slug/collections/reorder - Reorder a collection/page
+export const POST = withWorkspace(async ({ req, client, workspace, team }) => {
+  try {
+    const { id, index: newIndex, parent, object, newParent } = await reorderCollectionSchema.parseAsync(await req.json());
+
+
+    if (!ObjectId.isValid(id)) {
+      throw OrgniseApiError.BAD_REQUEST("Invalid id value");
+    }
+    if (newIndex < 0) {
+      throw OrgniseApiError.BAD_REQUEST("Invalid newIndex value");
+    }
+
+    const collectionsDb = collections<CollectionDbSchema>(client, "collections");
+    const query = { _id: new ObjectId(id), object: object, parent: new ObjectId(parent) };
+    const currentItem = (await collectionsDb.findOne(
+      query
+    )) as unknown as Collection;
+
+    if (!currentItem) {
+      throw OrgniseApiError.NOT_FOUND(`${object} with Id:${id} not found`);
+    }
+    else if (!newParent && currentItem.sortIndex === newIndex) {
+      return NextResponse.json({ success: true, message: `Result: ItemID - ${currentItem._id} moved to same index - ${newIndex}` });
+    }
+
+
+    if (!newParent) {
+      // console.log("\n 👉 Move to same column")
+      // Move within the same column: Update the order index of affected items
+
+      // Determine if moving forward or backward in the same column
+      const isForwardMove = newIndex > currentItem.sortIndex;
+      const increment = isForwardMove ? -1 : 1;
+
+      // Update order indexes based on move direction
+      if (isForwardMove) {
+        await collectionsDb.updateMany(
+          {
+            parent: currentItem.parent,
+            sortIndex: { $lte: newIndex, $gt: currentItem.sortIndex },
+            workspace: new ObjectId(workspace._id),
+            team: new ObjectId(team._id)
+          },
+          {
+            $inc: { sortIndex: -1 },
+            $set: { updatedAt: new Date() }
+          }
+        );
+        // console.log("\n 👉 Move in forward direction")
+      } else {
+        // console.log("\n 👉 Move in backward direction", { newIndex, current: currentItem.sortIndex })
+        await collectionsDb.updateMany(
+          {
+            parent: currentItem.parent,
+            sortIndex: { $gte: newIndex, $lt: currentItem.sortIndex },
+            workspace: new ObjectId(workspace._id),
+            team: new ObjectId(team._id)
+          },
+          {
+            $inc: { sortIndex: 1 },
+            $set: { updatedAt: new Date() }
+          }
+        );
+      }
+
+      // Set the new order index for the moved item
+      await collectionsDb.updateOne(
+        {
+          _id: new ObjectId(id),
+          workspace: new ObjectId(workspace._id),
+          team: new ObjectId(team._id)
+        },
+        { $set: { sortIndex: newIndex, updatedAt: new Date() } }
+      );
+
+    } else {
+
+      // console.log(`\n\n 1:)👉 Move to new column at index ${newIndex}`)
+      // Move to a new column: Update the item and adjust order indexes in both columns
+      await collectionsDb.updateOne(
+        {
+          _id: new ObjectId(id),
+          workspace: new ObjectId(workspace._id),
+          team: new ObjectId(team._id)
+        },
+        { $set: { parent: new ObjectId(newParent), sortIndex: newIndex, updatedAt: new Date() } }
+      );
+
+      // console.log(`\n 2:)👉 Updating previous column indexes greater then ${currentItem.sortIndex}`)
+      // Update order indexes in the previous column (decrement items after the moved item)
+      await collectionsDb.updateMany(
+        {
+          parent: new ObjectId(parent),
+          sortIndex: { $gt: currentItem.sortIndex },
+          workspace: new ObjectId(workspace._id),
+          team: new ObjectId(team._id)
+        },
+        {
+          $inc: { sortIndex: -1 },
+          $set: { updatedAt: new Date() }
+        }
+      );
+
+      // console.log(`\n 3:)👉 Update new column indexes greater then ${newIndex}`)
+      // Update order indexes in the new column (increment items after newIndex)
+      await collectionsDb.updateMany(
+        {
+          parent: new ObjectId(newParent),
+          sortIndex: { $gte: newIndex }, _id: { $ne: new ObjectId(id) },
+          workspace: new ObjectId(workspace._id),
+          team: new ObjectId(team._id),
+        },
+        {
+          $inc: { sortIndex: 1 },
+          $set: { updatedAt: new Date() }
+        }
+      );
+    }
+
+    return NextResponse.json({ success: true, message: `Result: ItemID - ${currentItem._id} moved to new Parent - ${newParent} at  Index - ${newIndex}` });
+
+  } catch (error: any) {
+    return handleAndReturnErrorResponse(error);
+  }
+});
+

--- a/src/app/api/teams/[team_slug]/[workspace_slug]/collections/reorder/route.ts
+++ b/src/app/api/teams/[team_slug]/[workspace_slug]/collections/reorder/route.ts
@@ -3,14 +3,14 @@ import { withWorkspace } from "@/lib/auth";
 import { CollectionDbSchema } from "@/lib/db-schema";
 import { collections } from "@/lib/mongodb";
 import { Collection } from "@/lib/types/types";
-import { reorderCollectionSchema } from "@/lib/zod/schemas";
+import { ReorderCollectionSchema } from "@/lib/zod/schemas";
 import { ObjectId } from "mongodb";
 import { NextResponse } from "next/server";
 
 // POST /api/teams/:team_slug/:workspace_slug/collections/reorder - Reorder a collection/page
 export const POST = withWorkspace(async ({ req, client, workspace, team }) => {
   try {
-    const { id, index: newIndex, parent, object, newParent } = await reorderCollectionSchema.parseAsync(await req.json());
+    const { id, index: newIndex, parent, object, newParent } = await ReorderCollectionSchema.parseAsync(await req.json());
 
 
     if (!ObjectId.isValid(id)) {

--- a/src/app/api/teams/[team_slug]/[workspace_slug]/collections/route.ts
+++ b/src/app/api/teams/[team_slug]/[workspace_slug]/collections/route.ts
@@ -59,13 +59,20 @@ export const POST = withWorkspace(async ({ team, workspace, session, req, params
       suffixLength: 6,
     });
 
+    // Total documents in the collection
+    const count = await collectionsDb.countDocuments({
+      team: new ObjectId(team._id),
+      workspace: new ObjectId(workspace._id),
+      parent: parent ? new ObjectId(parent) : null,
+    });
+
     const collection = {
       team: new ObjectId(team._id),
       meta: {
         slug: slug,
         title: name,
       },
-      sortIndex: 0,
+      sortIndex: count,
       name: name ?? "",
       object: object,
       parent: parent && new ObjectId(parent),

--- a/src/components/drag-n-drop/board-collections-view.tsx
+++ b/src/components/drag-n-drop/board-collections-view.tsx
@@ -1,0 +1,470 @@
+import { Collection } from "@/lib/types";
+import { triggerPostMoveFlash } from "@atlaskit/pragmatic-drag-and-drop-flourish/trigger-post-move-flash";
+import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
+import { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import invariant from "tiny-invariant";
+import Board from "./board";
+import {
+  BoardContext,
+  BoardContextValue,
+  ColumnMap,
+  ColumnType,
+} from "./board-context";
+import { Column } from "./column";
+import { getBasicData } from "./data";
+import { createRegistry } from "./registery";
+
+type Outcome =
+  | {
+      type: "column-reorder";
+      columnId: string;
+      startIndex: number;
+      finishIndex: number;
+    }
+  | {
+      type: "card-reorder";
+      columnId: string;
+      startIndex: number;
+      finishIndex: number;
+    }
+  | {
+      type: "card-move";
+      finishColumnId: string;
+      itemIndexInStartColumn: number;
+      itemIndexInFinishColumn: number;
+    };
+
+type Trigger = "pointer" | "keyboard";
+
+type Operation = {
+  trigger: Trigger;
+  outcome: Outcome;
+};
+
+type BoardState = {
+  columnMap: ColumnMap;
+  orderedColumnIds: string[];
+  lastOperation: Operation | null;
+};
+
+export default function BoardCollectionView({
+  collections,
+}: {
+  collections: Collection[];
+}) {
+  const [data, setData] = useState<BoardState>(() => {
+    const base = getBasicData(collections);
+    return {
+      ...base,
+      lastOperation: null,
+    };
+  });
+
+  const stableData = useRef<BoardState>(data);
+
+  const [registry] = useState(createRegistry);
+
+  const { lastOperation } = data;
+
+  useEffect(() => {
+    if (lastOperation === null) {
+      return;
+    }
+    const { outcome, trigger } = lastOperation;
+
+    if (outcome.type === "column-reorder") {
+      const { startIndex, finishIndex } = outcome;
+
+      const { columnMap, orderedColumnIds } = stableData.current;
+      const sourceColumn = columnMap[orderedColumnIds[finishIndex]];
+
+      const entry = registry.getColumn(sourceColumn.columnId);
+      triggerPostMoveFlash(entry.element);
+      return;
+    }
+
+    if (outcome.type === "card-reorder") {
+      const { columnId, startIndex, finishIndex } = outcome;
+
+      const { columnMap } = stableData.current;
+      const column = columnMap[columnId];
+      const item = column.items[finishIndex];
+
+      const entry = registry.getCard(item._id);
+      triggerPostMoveFlash(entry.element);
+
+      if (trigger !== "keyboard") {
+        return;
+      }
+      return;
+    }
+
+    if (outcome.type === "card-move") {
+      const {
+        finishColumnId,
+        itemIndexInStartColumn,
+        itemIndexInFinishColumn,
+      } = outcome;
+
+      const data = stableData.current;
+      const destinationColumn = data.columnMap[finishColumnId];
+      const item = destinationColumn.items[itemIndexInFinishColumn];
+      if (!item) {
+        console.log("item not found", {
+          finishColumnId,
+          itemIndexInFinishColumn,
+        });
+        return;
+      }
+      const finishPosition =
+        typeof itemIndexInFinishColumn === "number"
+          ? itemIndexInFinishColumn + 1
+          : destinationColumn.items.length;
+
+      const entry = registry.getCard(item._id);
+      triggerPostMoveFlash(entry.element);
+
+      if (trigger !== "keyboard") {
+        return;
+      }
+
+      /**
+       * Because the card has moved column, it will have remounted.
+       * This means we need to manually restore focus to it.
+       */
+      entry.actionMenuTrigger.focus();
+
+      return;
+    }
+  }, [lastOperation, registry]);
+
+  const getColumns = useCallback(() => {
+    const { columnMap, orderedColumnIds } = stableData.current;
+    return orderedColumnIds.map((columnId: any) => columnMap[columnId]);
+  }, []);
+
+  const reorderColumn = useCallback(
+    ({
+      startIndex,
+      finishIndex,
+      trigger = "keyboard",
+    }: {
+      startIndex: number;
+      finishIndex: number;
+      trigger?: Trigger;
+    }) => {
+      console.log({ startIndex, finishIndex });
+      setData((data) => {
+        const outcome: Outcome = {
+          type: "column-reorder",
+          columnId: data.orderedColumnIds[startIndex],
+          startIndex,
+          finishIndex,
+        };
+
+        return {
+          ...data,
+          orderedColumnIds: reorder({
+            list: data.orderedColumnIds,
+            startIndex,
+            finishIndex,
+          }),
+          lastOperation: {
+            outcome,
+            trigger: trigger,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const reorderCard = useCallback(
+    ({
+      columnId,
+      startIndex,
+      finishIndex,
+      trigger = "keyboard",
+    }: {
+      columnId: string;
+      startIndex: number;
+      finishIndex: number;
+      trigger?: Trigger;
+    }) => {
+      console.log({ columnId, startIndex, finishIndex });
+      setData((data) => {
+        const sourceColumn = data.columnMap[columnId];
+        const updatedItems = reorder({
+          list: sourceColumn.items,
+          startIndex,
+          finishIndex,
+        });
+
+        const updatedSourceColumn: ColumnType = {
+          ...sourceColumn,
+          items: updatedItems,
+        };
+
+        const updatedMap: ColumnMap = {
+          ...data.columnMap,
+          [columnId]: updatedSourceColumn,
+        };
+
+        const outcome: Outcome | null = {
+          type: "card-reorder",
+          columnId,
+          startIndex,
+          finishIndex,
+        };
+
+        return {
+          ...data,
+          columnMap: updatedMap,
+          lastOperation: {
+            trigger: trigger,
+            outcome,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const moveCard = useCallback(
+    ({
+      startColumnId,
+      finishColumnId,
+      itemIndexInStartColumn,
+      itemIndexInFinishColumn,
+      trigger = "keyboard",
+    }: {
+      startColumnId: string;
+      finishColumnId: string;
+      itemIndexInStartColumn: number;
+      itemIndexInFinishColumn?: number;
+      trigger?: "pointer" | "keyboard";
+    }) => {
+      console.log({
+        startColumnId,
+        finishColumnId,
+        itemIndexInStartColumn,
+        itemIndexInFinishColumn,
+      });
+      // invalid cross column movement
+      if (startColumnId === finishColumnId) {
+        return;
+      }
+      setData((data) => {
+        const sourceColumn = data.columnMap[startColumnId];
+        const destinationColumn = data.columnMap[finishColumnId];
+        const item: Collection = sourceColumn.items[itemIndexInStartColumn];
+
+        const destinationItems = Array.from(destinationColumn.items);
+        // Going into the first position if no index is provided
+        const newIndexInDestination = itemIndexInFinishColumn ?? 0;
+        destinationItems.splice(newIndexInDestination, 0, item);
+
+        const updatedMap = {
+          ...data.columnMap,
+          [startColumnId]: {
+            ...sourceColumn,
+            items: sourceColumn.items.filter((i) => i._id !== item._id),
+          },
+          [finishColumnId]: {
+            ...destinationColumn,
+            items: destinationItems,
+          },
+        };
+
+        const outcome: Outcome | null = {
+          type: "card-move",
+          finishColumnId,
+          itemIndexInStartColumn,
+          itemIndexInFinishColumn: newIndexInDestination,
+        };
+
+        return {
+          ...data,
+          columnMap: updatedMap,
+          lastOperation: {
+            outcome,
+            trigger: trigger,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const [instanceId] = useState(() => Symbol("instance-id"));
+
+  const contextValue: BoardContextValue = useMemo(() => {
+    return {
+      getColumns,
+      reorderColumn,
+      reorderCard,
+      moveCard,
+      registerCard: registry.registerCard,
+      registerColumn: registry.registerColumn,
+      instanceId,
+    };
+  }, [getColumns, reorderColumn, reorderCard, registry, moveCard, instanceId]);
+
+  useEffect(() => {
+    stableData.current = data;
+  }, [data]);
+
+  useEffect(() => {
+    return combine(
+      monitorForElements({
+        canMonitor({ source }) {
+          return source.data.instanceId === instanceId;
+        },
+        onDrop(args) {
+          const { location, source } = args;
+          // didn't drop on anything
+          if (!location.current.dropTargets.length) {
+            return;
+          }
+          // need to handle drop
+
+          // 1. remove element from original position
+          // 2. move to new position
+
+          if (source.data.type === "column") {
+            const startIndex: number = data.orderedColumnIds.findIndex(
+              (columnId) => columnId === source.data.columnId,
+            );
+
+            const target = location.current.dropTargets[0];
+            const indexOfTarget: number = data.orderedColumnIds.findIndex(
+              (id) => id === target.data.columnId,
+            );
+            const closestEdgeOfTarget: Edge | null = extractClosestEdge(
+              target.data,
+            );
+
+            const finishIndex = getReorderDestinationIndex({
+              startIndex,
+              indexOfTarget,
+              closestEdgeOfTarget,
+              axis: "horizontal",
+            });
+
+            reorderColumn({ startIndex, finishIndex, trigger: "pointer" });
+          }
+          // Dragging a card
+          if (source.data.type === "card") {
+            const itemId = source.data.itemId;
+            invariant(typeof itemId === "string");
+            // TODO: these lines not needed if item has columnId on it
+            const [, startColumnRecord] = location.initial.dropTargets;
+            const sourceId = startColumnRecord.data.columnId;
+            invariant(typeof sourceId === "string");
+            const sourceColumn = data.columnMap[sourceId];
+            const itemIndex = sourceColumn.items.findIndex(
+              (item) => item._id === itemId,
+            );
+
+            if (location.current.dropTargets.length === 1) {
+              const [destinationColumnRecord] = location.current.dropTargets;
+              const destinationId = destinationColumnRecord.data.columnId;
+              invariant(typeof destinationId === "string");
+              const destinationColumn = data.columnMap[destinationId];
+              invariant(destinationColumn);
+
+              // reordering in same column
+              if (sourceColumn === destinationColumn) {
+                const destinationIndex = getReorderDestinationIndex({
+                  startIndex: itemIndex,
+                  indexOfTarget: sourceColumn.items.length - 1,
+                  closestEdgeOfTarget: null,
+                  axis: "vertical",
+                });
+                reorderCard({
+                  columnId: sourceColumn.columnId,
+                  startIndex: itemIndex,
+                  finishIndex: destinationIndex,
+                  trigger: "pointer",
+                });
+                return;
+              }
+
+              // moving to a new column
+              moveCard({
+                itemIndexInStartColumn: itemIndex,
+                startColumnId: sourceColumn.columnId,
+                finishColumnId: destinationColumn.columnId,
+                trigger: "pointer",
+              });
+              return;
+            }
+
+            // dropping in a column (relative to a card)
+            if (location.current.dropTargets.length === 2) {
+              const [destinationCardRecord, destinationColumnRecord] =
+                location.current.dropTargets;
+              const destinationColumnId = destinationColumnRecord.data.columnId;
+              invariant(typeof destinationColumnId === "string");
+              const destinationColumn = data.columnMap[destinationColumnId];
+
+              const indexOfTarget = destinationColumn.items.findIndex(
+                (item) => item._id === destinationCardRecord.data.itemId,
+              );
+              const closestEdgeOfTarget: Edge | null = extractClosestEdge(
+                destinationCardRecord.data,
+              );
+
+              // case 1: ordering in the same column
+              if (sourceColumn === destinationColumn) {
+                const destinationIndex = getReorderDestinationIndex({
+                  startIndex: itemIndex,
+                  indexOfTarget,
+                  closestEdgeOfTarget,
+                  axis: "vertical",
+                });
+                reorderCard({
+                  columnId: sourceColumn.columnId,
+                  startIndex: itemIndex,
+                  finishIndex: destinationIndex,
+                  trigger: "pointer",
+                });
+                return;
+              }
+
+              // case 2: moving into a new column relative to a card
+
+              const destinationIndex =
+                closestEdgeOfTarget === "bottom"
+                  ? indexOfTarget + 1
+                  : indexOfTarget;
+
+              moveCard({
+                itemIndexInStartColumn: itemIndex,
+                startColumnId: sourceColumn.columnId,
+                finishColumnId: destinationColumn.columnId,
+                itemIndexInFinishColumn: destinationIndex,
+                trigger: "pointer",
+              });
+            }
+          }
+        },
+      }),
+    );
+  }, [data, instanceId, moveCard, reorderCard, reorderColumn]);
+
+  return (
+    <BoardContext.Provider value={contextValue}>
+      <Board>
+        {data.orderedColumnIds.map((columnId) => {
+          return <Column column={data.columnMap[columnId]} key={columnId} />;
+        })}
+      </Board>
+    </BoardContext.Provider>
+  );
+}

--- a/src/components/drag-n-drop/board-context.tsx
+++ b/src/components/drag-n-drop/board-context.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext } from "react";
+
+import invariant from "tiny-invariant";
+
+import { Collection } from "@/lib/types";
+import type { CleanupFn } from "@atlaskit/pragmatic-drag-and-drop/types";
+
+export type ColumnType = {
+  title: string;
+  columnId: string;
+  items: Collection[];
+};
+export type ColumnMap = { [columnId: string]: ColumnType };
+
+export type BoardContextValue = {
+  getColumns: () => ColumnType[];
+
+  reorderColumn: (args: { startIndex: number; finishIndex: number }) => void;
+
+  reorderCard: (args: {
+    columnId: string;
+    startIndex: number;
+    finishIndex: number;
+  }) => void;
+
+  moveCard: (args: {
+    startColumnId: string;
+    finishColumnId: string;
+    itemIndexInStartColumn: number;
+    itemIndexInFinishColumn?: number;
+  }) => void;
+
+  registerCard: (args: {
+    cardId: string;
+    entry: {
+      element: HTMLElement;
+      actionMenuTrigger: HTMLElement;
+    };
+  }) => CleanupFn;
+
+  registerColumn: (args: {
+    columnId: string;
+    entry: {
+      element: HTMLElement;
+    };
+  }) => CleanupFn;
+
+  instanceId: symbol;
+};
+
+export const BoardContext = createContext<BoardContextValue | null>(null);
+
+export function useBoardContext(): BoardContextValue {
+  const value = useContext(BoardContext);
+  invariant(value, "cannot find BoardContext provider");
+  return value;
+}

--- a/src/components/drag-n-drop/board.tsx
+++ b/src/components/drag-n-drop/board.tsx
@@ -20,7 +20,7 @@ const Board = forwardRef<HTMLDivElement, BoardProps>(
     return (
       <div
         ref={ref}
-        className="Board flex h-full w-full flex-row  gap-4 overflow-auto p-4"
+        className="Board flex h-full w-full flex-row  gap-4 overflow-auto bg-background p-4"
       >
         {children}
       </div>

--- a/src/components/drag-n-drop/board.tsx
+++ b/src/components/drag-n-drop/board.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, useEffect, type ReactNode } from "react";
+
+import { autoScrollWindowForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+
+import { useBoardContext } from "./board-context";
+
+type BoardProps = {
+  children: ReactNode;
+};
+
+const Board = forwardRef<HTMLDivElement, BoardProps>(
+  ({ children }: BoardProps, ref) => {
+    const { instanceId } = useBoardContext();
+
+    useEffect(() => {
+      return autoScrollWindowForElements({
+        canScroll: ({ source }) => source.data.instanceId === instanceId,
+      });
+    }, [instanceId]);
+    return (
+      <div
+        ref={ref}
+        className="Board flex h-full w-full flex-row  gap-4 overflow-auto p-4"
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+Board.displayName = "Board";
+export default Board;

--- a/src/components/drag-n-drop/card.tsx
+++ b/src/components/drag-n-drop/card.tsx
@@ -1,0 +1,240 @@
+import {
+  Fragment,
+  forwardRef,
+  memo,
+  useEffect,
+  useRef,
+  useState,
+  type Ref,
+} from "react";
+
+import ReactDOM from "react-dom";
+import invariant from "tiny-invariant";
+// This is the smaller MoreIcon soon to be more easily accessible with the
+// ongoing icon project
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+  type Edge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { preserveOffsetOnSource } from "@atlaskit/pragmatic-drag-and-drop/element/preserve-offset-on-source";
+import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
+import { Box, Stack, xcss } from "@atlaskit/primitives";
+
+import { Collection } from "@/lib/types";
+import { hasValue } from "@/lib/utils";
+import clsx from "clsx";
+import { H4 } from "../atom/typography";
+import { useBoardContext } from "./board-context";
+
+type State =
+  | { type: "idle" }
+  | { type: "preview"; container: HTMLElement; rect: DOMRect }
+  | { type: "dragging" };
+
+const idleState: State = { type: "idle" };
+const draggingState: State = { type: "dragging" };
+
+const noMarginStyles = xcss({ margin: "space.0" });
+const baseStyles = xcss({
+  width: "100%",
+  padding: "space.100",
+  backgroundColor: "elevation.surface",
+  borderRadius: "border.radius.200",
+  position: "relative",
+  ":hover": {
+    backgroundColor: "elevation.surface.hovered",
+  },
+});
+
+const stateStyles: {
+  [Key in State["type"]]: ReturnType<typeof xcss> | undefined;
+} = {
+  idle: xcss({
+    cursor: "grab",
+    boxShadow: "elevation.shadow.raised",
+  }),
+  dragging: xcss({
+    opacity: 0.4,
+    boxShadow: "elevation.shadow.raised",
+  }),
+  // no shadow for preview - the platform will add it's own drop shadow
+  preview: undefined,
+};
+
+type CardPrimitiveProps = {
+  closestEdge: Edge | null;
+  item: Collection;
+  state: State;
+  actionMenuTriggerRef?: Ref<HTMLButtonElement>;
+};
+
+const CardPrimitive = forwardRef<HTMLDivElement, CardPrimitiveProps>(
+  function CardPrimitive(
+    { closestEdge, item, state, actionMenuTriggerRef },
+    ref,
+  ) {
+    const { name, _id } = item;
+
+    return (
+      <div
+        ref={ref}
+        id={`item-${_id}`}
+        className="relative flex flex-col gap-1"
+      >
+        {closestEdge && (
+          <div
+            className={clsx(
+              "-left-2 -right-3  flex w-[106%] flex-row items-center",
+              {
+                "absolute -top-2 ": closestEdge === "top",
+                "absolute -bottom-2": closestEdge === "bottom",
+              },
+            )}
+          >
+            <div className="flex h-2 w-2 place-content-center items-center rounded-full bg-info">
+              <div className="h-1 w-1 rounded-full bg-info-foreground" />
+            </div>
+            <div className="h-0.5 flex-grow rounded bg-info" />
+            <div className="flex h-2 w-2 place-content-center items-center rounded-full bg-info">
+              <div className="h-1 w-1 rounded-full bg-info-foreground" />
+            </div>
+          </div>
+        )}
+        <div className="rounded bg-card p-2 shadow hover:bg-accent">
+          <Stack space="space.050" grow="fill" ref={actionMenuTriggerRef}>
+            {hasValue(name) ? (
+              <H4>{name}</H4>
+            ) : (
+              <H4 className="text-secondary-foreground/60">Untitled Page</H4>
+            )}
+          </Stack>
+        </div>
+      </div>
+    );
+  },
+);
+
+export const Card = memo(function Card({ item }: { item: Collection }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { _id } = item;
+  const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
+  const [state, setState] = useState<State>(idleState);
+
+  const actionMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const { instanceId, registerCard } = useBoardContext();
+  useEffect(() => {
+    invariant(actionMenuTriggerRef.current);
+    invariant(ref.current);
+    return registerCard({
+      cardId: _id,
+      entry: {
+        element: ref.current,
+        actionMenuTrigger: actionMenuTriggerRef.current,
+      },
+    });
+  }, [registerCard, _id]);
+
+  useEffect(() => {
+    const element = ref.current;
+    invariant(element);
+    return combine(
+      draggable({
+        element: element,
+        getInitialData: () => ({ type: "card", itemId: _id, instanceId }),
+        onGenerateDragPreview: ({ location, source, nativeSetDragImage }) => {
+          const rect = source.element.getBoundingClientRect();
+
+          setCustomNativeDragPreview({
+            nativeSetDragImage,
+            getOffset: preserveOffsetOnSource({
+              element,
+              input: location.current.input,
+            }),
+            render({ container }) {
+              setState({ type: "preview", container, rect });
+              return () => setState(draggingState);
+            },
+          });
+        },
+
+        onDragStart: () => setState(draggingState),
+        onDrop: () => setState(idleState),
+      }),
+      dropTargetForExternal({
+        element: element,
+      }),
+      dropTargetForElements({
+        element: element,
+        canDrop: ({ source }) => {
+          return (
+            source.data.instanceId === instanceId && source.data.type === "card"
+          );
+        },
+        getIsSticky: () => true,
+        getData: ({ input, element }) => {
+          const data = { type: "card", itemId: _id };
+
+          return attachClosestEdge(data, {
+            input,
+            element,
+            allowedEdges: ["top", "bottom"],
+          });
+        },
+        onDragEnter: (args) => {
+          if (args.source.data.itemId !== _id) {
+            setClosestEdge(extractClosestEdge(args.self.data));
+          }
+        },
+        onDrag: (args) => {
+          if (args.source.data.itemId !== _id) {
+            setClosestEdge(extractClosestEdge(args.self.data));
+          }
+        },
+        onDragLeave: () => {
+          setClosestEdge(null);
+        },
+        onDrop: () => {
+          setClosestEdge(null);
+        },
+      }),
+    );
+  }, [instanceId, item, _id]);
+
+  return (
+    <Fragment>
+      <CardPrimitive
+        ref={ref}
+        item={item}
+        state={state}
+        closestEdge={closestEdge}
+        actionMenuTriggerRef={actionMenuTriggerRef}
+      />
+      {state.type === "preview" &&
+        ReactDOM.createPortal(
+          <Box
+            style={{
+              /**
+               * Ensuring the preview has the same dimensions as the original.
+               *
+               * Using `border-box` sizing here is not necessary in this
+               * specific example, but it is safer to include generally.
+               */
+              boxSizing: "border-box",
+              width: state.rect.width,
+              height: state.rect.height,
+            }}
+          >
+            <CardPrimitive item={item} state={state} closestEdge={null} />
+          </Box>,
+          state.container,
+        )}
+    </Fragment>
+  );
+});

--- a/src/components/drag-n-drop/column-context.tsx
+++ b/src/components/drag-n-drop/column-context.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+import invariant from "tiny-invariant";
+
+export type ColumnContextProps = {
+  columnId: string;
+  getCardIndex: (id: string) => number;
+  getNumCards: () => number;
+};
+
+export const ColumnContext = createContext<ColumnContextProps | null>(null);
+
+export function useColumnContext(): ColumnContextProps {
+  const value = useContext(ColumnContext);
+  invariant(value, "cannot find ColumnContext provider");
+  return value;
+}

--- a/src/components/drag-n-drop/column.tsx
+++ b/src/components/drag-n-drop/column.tsx
@@ -1,0 +1,326 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+  type Edge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
+import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import { Box, Stack, xcss } from "@atlaskit/primitives";
+import { createPortal } from "react-dom";
+import invariant from "tiny-invariant";
+
+import { Collection } from "@/lib/types";
+import { hasValue } from "@/lib/utils";
+import clsx from "clsx";
+import { H2, H3 } from "../atom/typography";
+import { ColumnType, useBoardContext } from "./board-context";
+import { Card } from "./card";
+import { ColumnContext, type ColumnContextProps } from "./column-context";
+
+const cardListStyles = xcss({
+  boxSizing: "border-box",
+  minHeight: "100%",
+  padding: "space.100",
+  gap: "space.100",
+});
+
+const columnHeaderStyles = xcss({
+  paddingInlineStart: "space.200",
+  paddingInlineEnd: "space.200",
+  paddingBlockStart: "space.100",
+  color: "color.text.subtlest",
+  userSelect: "none",
+});
+
+/**
+ * Note: not making `'is-dragging'` a `State` as it is
+ * a _parallel_ state to `'is-column-over'`.
+ *
+ * Our board allows you to be over the column that is currently dragging
+ */
+type State =
+  | { type: "idle" }
+  | { type: "is-card-over" }
+  | { type: "is-column-over"; closestEdge: Edge | null }
+  | { type: "generate-safari-column-preview"; container: HTMLElement }
+  | { type: "generate-column-preview" };
+
+// preventing re-renders with stable state objects
+const idle: State = { type: "idle" };
+const isCardOver: State = { type: "is-card-over" };
+
+const stateStyles: {
+  [key in State["type"]]: ReturnType<typeof xcss> | undefined;
+} = {
+  idle: xcss({
+    cursor: "grab",
+  }),
+  "is-card-over": xcss({
+    backgroundColor: "color.background.selected.hovered",
+  }),
+  "is-column-over": undefined,
+  /**
+   * **Browser bug workaround**
+   *
+   * _Problem_
+   * When generating a drag preview for an element
+   * that has an inner scroll container, the preview can include content
+   * vertically before or after the element
+   *
+   * _Fix_
+   * We make the column a new stacking context when the preview is being generated.
+   * We are not making a new stacking context at all times, as this _can_ mess up
+   * other layering components inside of your card
+   *
+   * _Fix: Safari_
+   * We have not found a great workaround yet. So for now we are just rendering
+   * a custom drag preview
+   */
+  "generate-column-preview": xcss({
+    isolation: "isolate",
+  }),
+  "generate-safari-column-preview": undefined,
+};
+
+export const Column = memo(function Column({ column }: { column: ColumnType }) {
+  const columnId = column.columnId;
+  const columnRef = useRef<HTMLDivElement | null>(null);
+  const columnInnerRef = useRef<HTMLDivElement | null>(null);
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const scrollableRef = useRef<HTMLDivElement | null>(null);
+  const [state, setState] = useState<State>(idle);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+
+  const { instanceId, registerColumn } = useBoardContext();
+
+  useEffect(() => {
+    invariant(columnRef.current);
+    invariant(columnInnerRef.current);
+    invariant(headerRef.current);
+    invariant(scrollableRef.current);
+    return combine(
+      registerColumn({
+        columnId,
+        entry: {
+          element: columnRef.current,
+        },
+      }),
+      draggable({
+        element: columnRef.current,
+        dragHandle: headerRef.current,
+        getInitialData: () => ({ columnId, type: "column", instanceId }),
+        onGenerateDragPreview: ({ nativeSetDragImage }) => {
+          const isSafari: boolean =
+            navigator.userAgent.includes("AppleWebKit") &&
+            !navigator.userAgent.includes("Chrome");
+
+          if (!isSafari) {
+            setState({ type: "generate-column-preview" });
+            return;
+          }
+          setCustomNativeDragPreview({
+            getOffset: centerUnderPointer,
+            render: ({ container }) => {
+              setState({
+                type: "generate-safari-column-preview",
+                container,
+              });
+              return () => setState(idle);
+            },
+            nativeSetDragImage,
+          });
+        },
+        onDragStart: () => {
+          setIsDragging(true);
+        },
+        onDrop() {
+          setState(idle);
+          setIsDragging(false);
+        },
+      }),
+      dropTargetForElements({
+        element: columnInnerRef.current,
+        getData: () => ({ columnId }),
+        canDrop: ({ source }) => {
+          return (
+            source.data.instanceId === instanceId && source.data.type === "card"
+          );
+        },
+        getIsSticky: () => true,
+        onDragEnter: () => setState(isCardOver),
+        onDragLeave: () => setState(idle),
+        onDragStart: () => setState(isCardOver),
+        onDrop: () => setState(idle),
+      }),
+      dropTargetForElements({
+        element: columnRef.current,
+        canDrop: ({ source }) => {
+          return (
+            source.data.instanceId === instanceId &&
+            source.data.type === "column"
+          );
+        },
+        getIsSticky: () => true,
+        getData: ({ input, element }) => {
+          const data = {
+            columnId,
+          };
+          return attachClosestEdge(data, {
+            input,
+            element,
+            allowedEdges: ["left", "right"],
+          });
+        },
+        onDragEnter: (args) => {
+          setState({
+            type: "is-column-over",
+            closestEdge: extractClosestEdge(args.self.data),
+          });
+        },
+        onDrag: (args) => {
+          // skip react re-render if edge is not changing
+          setState((current) => {
+            const closestEdge: Edge | null = extractClosestEdge(args.self.data);
+            if (
+              current.type === "is-column-over" &&
+              current.closestEdge === closestEdge
+            ) {
+              return current;
+            }
+            return {
+              type: "is-column-over",
+              closestEdge,
+            };
+          });
+        },
+        onDragLeave: () => {
+          setState(idle);
+        },
+        onDrop: () => {
+          setState(idle);
+        },
+      }),
+      autoScrollForElements({
+        element: scrollableRef.current,
+        canScroll: ({ source }) =>
+          source.data.instanceId === instanceId && source.data.type === "card",
+      }),
+    );
+  }, [columnId, registerColumn, instanceId]);
+
+  const stableItems = useRef(column.items);
+  useEffect(() => {
+    stableItems.current = column.items;
+  }, [column.items]);
+
+  const getCardIndex = useCallback((id: string) => {
+    return stableItems.current.findIndex((item: Collection) => item._id === id);
+  }, []);
+
+  const getNumCards = useCallback(() => {
+    return stableItems.current.length;
+  }, []);
+
+  const contextValue: ColumnContextProps = useMemo(() => {
+    return { columnId, getCardIndex, getNumCards };
+  }, [columnId, getCardIndex, getNumCards]);
+
+  return (
+    <ColumnContext.Provider value={contextValue}>
+      <div className="relative">
+        <div
+          id={`column-${columnId}`}
+          ref={columnRef}
+          className={clsx(
+            " flex h-[calc(100%-64px)] w-64 min-w-64 cursor-grab flex-col gap-1 overflow-y-auto rounded-lg bg-accent/70 transition-colors duration-200",
+            {
+              "opacity-40": isDragging,
+              "bg-info/30": state.type === "is-card-over",
+              isolate: state.type === "generate-column-preview",
+            },
+          )}
+        >
+          {/* This element takes up the same visual space as the column.
+          We are using a separate element so we can have two drop targets
+          that take up the same visual space (one for cards, one for columns)
+        */}
+          <div className={"min-h-0 flex-grow"} ref={columnInnerRef}>
+            <div
+              className={clsx("min-h-0 flex-grow", {
+                "opacity-40": isDragging,
+              })}
+            >
+              <div
+                ref={headerRef}
+                id={`column-header-${columnId}`}
+                className="Header sticky top-0 flex items-center justify-between rounded-t-lg bg-accent p-2 text-secondary-foreground/60"
+              >
+                <H3 id={`column-header-title-${columnId}`}>
+                  {hasValue(column.title) ? column.title : "Untitled Column"}
+                </H3>
+                {/* <ActionMenu /> */}
+              </div>
+              <div className="h-full overflow-y-auto" ref={scrollableRef}>
+                <Stack xcss={cardListStyles} space="space.100">
+                  {column.items.map((item: Collection) => (
+                    <Card item={item} key={item._id} />
+                  ))}
+                </Stack>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* SEPARATOR */}
+        {state.type === "is-column-over" && state.closestEdge && (
+          <div
+            className={clsx(
+              "flex h-[calc(100%-64px)]   flex-col items-center",
+              {
+                invisible: state.type !== "is-column-over",
+                "absolute -left-2 bottom-0 top-0 ":
+                  state.closestEdge === "left",
+                "absolute bottom-0 right-3 top-0":
+                  state.closestEdge === "right",
+              },
+            )}
+          >
+            <div className="flex h-2 w-2 place-content-center items-center rounded-full bg-info">
+              <div className="h-1 w-1 rounded-full bg-info-foreground" />
+            </div>
+            <div className="w-0.5 flex-grow rounded bg-info" />
+            <div className="flex h-2 w-2 place-content-center items-center rounded-full bg-info">
+              <div className="h-1 w-1 rounded-full bg-info-foreground" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {state.type === "generate-safari-column-preview"
+        ? createPortal(<SafariColumnPreview column={column} />, state.container)
+        : null}
+    </ColumnContext.Provider>
+  );
+});
+
+const safariPreviewStyles = xcss({
+  width: "250px",
+  backgroundColor: "elevation.surface.sunken",
+  borderRadius: "border.radius",
+  padding: "space.200",
+});
+
+function SafariColumnPreview({ column }: { column: ColumnType }) {
+  return (
+    <Box xcss={[columnHeaderStyles, safariPreviewStyles]}>
+      <H2>{column.title}</H2>
+    </Box>
+  );
+}

--- a/src/components/drag-n-drop/column.tsx
+++ b/src/components/drag-n-drop/column.tsx
@@ -13,7 +13,7 @@ import {
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
-import { Box, Stack, xcss } from "@atlaskit/primitives";
+import { Box, xcss } from "@atlaskit/primitives";
 import { createPortal } from "react-dom";
 import invariant from "tiny-invariant";
 
@@ -22,15 +22,8 @@ import { hasValue } from "@/lib/utils";
 import clsx from "clsx";
 import { H2, H3 } from "../atom/typography";
 import { ColumnType, useBoardContext } from "./board-context";
-import { Card } from "./card";
+import { Card } from "./column-card";
 import { ColumnContext, type ColumnContextProps } from "./column-context";
-
-const cardListStyles = xcss({
-  boxSizing: "border-box",
-  minHeight: "100%",
-  padding: "space.100",
-  gap: "space.100",
-});
 
 const columnHeaderStyles = xcss({
   paddingInlineStart: "space.200",
@@ -240,7 +233,7 @@ export const Column = memo(function Column({ column }: { column: ColumnType }) {
           id={`column-${columnId}`}
           ref={columnRef}
           className={clsx(
-            " flex h-[calc(100%-64px)] w-64 min-w-64 cursor-grab flex-col gap-1 overflow-y-auto rounded-lg bg-accent/70 transition-colors duration-200",
+            " flex h-[calc(100%-64px)] w-64 min-w-64 cursor-grab flex-col gap-1 overflow-y-auto rounded-lg bg-accent transition-colors duration-200",
             {
               "opacity-40": isDragging,
               "bg-info/30": state.type === "is-card-over",
@@ -261,7 +254,7 @@ export const Column = memo(function Column({ column }: { column: ColumnType }) {
               <div
                 ref={headerRef}
                 id={`column-header-${columnId}`}
-                className="Header sticky top-0 flex items-center justify-between rounded-t-lg bg-accent p-2 text-secondary-foreground/60"
+                className="Header sticky top-0 z-10 flex items-center justify-between rounded-t-lg bg-accent p-2 text-secondary-foreground/60"
               >
                 <H3 id={`column-header-title-${columnId}`}>
                   {hasValue(column.title) ? column.title : "Untitled Column"}
@@ -269,11 +262,17 @@ export const Column = memo(function Column({ column }: { column: ColumnType }) {
                 {/* <ActionMenu /> */}
               </div>
               <div className="h-full overflow-y-auto" ref={scrollableRef}>
-                <Stack xcss={cardListStyles} space="space.100">
+                <div
+                  className="flex flex-col gap-2 px-2 pb-4"
+                  style={{
+                    minHeight: "100%",
+                    boxSizing: "border-box",
+                  }}
+                >
                   {column.items.map((item: Collection) => (
                     <Card item={item} key={item._id} />
                   ))}
-                </Stack>
+                </div>
               </div>
             </div>
           </div>
@@ -282,7 +281,7 @@ export const Column = memo(function Column({ column }: { column: ColumnType }) {
         {state.type === "is-column-over" && state.closestEdge && (
           <div
             className={clsx(
-              "flex h-[calc(100%-64px)]   flex-col items-center",
+              "flex h-[calc(100%-64px)]   flex-col items-center scroll-smooth",
               {
                 invisible: state.type !== "is-column-over",
                 "absolute -left-2 bottom-0 top-0 ":

--- a/src/components/drag-n-drop/data.ts
+++ b/src/components/drag-n-drop/data.ts
@@ -13,10 +13,11 @@ export function getBasicData(collections: Collection[]) {
   const outputData: ColumnMap = {};
 
   columns.forEach((item) => {
+    const list = item.items.sort((a, b) => a.sortIndex - b.sortIndex);
     outputData[item.columnId] = {
       title: item.title,
       columnId: item.columnId,
-      items: item.items,
+      items: list,
     };
   });
 

--- a/src/components/drag-n-drop/data.tsx
+++ b/src/components/drag-n-drop/data.tsx
@@ -1,0 +1,29 @@
+import { Collection } from "@/lib/types";
+import { ColumnMap } from "./board-context";
+
+export function getBasicData(collections: Collection[]) {
+  const columns = collections.map((coll, index) => {
+    return {
+      title: coll.name,
+      columnId: coll._id,
+      items: coll.children,
+    };
+  });
+
+  const outputData: ColumnMap = {};
+
+  columns.forEach((item) => {
+    outputData[item.columnId] = {
+      title: item.title,
+      columnId: item.columnId,
+      items: item.items,
+    };
+  });
+
+  const orderedColumnIds = collections.map((coll) => coll._id);
+
+  return {
+    columnMap: outputData,
+    orderedColumnIds,
+  };
+}

--- a/src/components/drag-n-drop/registery.ts
+++ b/src/components/drag-n-drop/registery.ts
@@ -1,0 +1,55 @@
+import invariant from 'tiny-invariant';
+
+import type { CleanupFn } from '@atlaskit/pragmatic-drag-and-drop/types';
+
+export type CardEntry = {
+  element: HTMLElement;
+  actionMenuTrigger: HTMLElement;
+};
+
+export type ColumnEntry = {
+  element: HTMLElement;
+};
+
+/**
+ * Registering cards and their action menu trigger element,
+ * so that we can restore focus to the trigger when a card moves between columns.
+ */
+export function createRegistry() {
+  const cards = new Map<string, CardEntry>();
+  const columns = new Map<string, ColumnEntry>();
+
+  function registerCard({ cardId, entry }: { cardId: string; entry: CardEntry }): CleanupFn {
+    cards.set(cardId, entry);
+    return function cleanup() {
+      cards.delete(cardId);
+    };
+  }
+
+  function registerColumn({
+    columnId,
+    entry,
+  }: {
+    columnId: string;
+    entry: ColumnEntry;
+  }): CleanupFn {
+    columns.set(columnId, entry);
+    return function cleanup() {
+      cards.delete(columnId);
+    };
+  }
+
+  function getCard(cardId: string): CardEntry {
+    const entry = cards.get(cardId);
+    invariant(entry);
+    return entry;
+  }
+
+  function getColumn(columnId: string): ColumnEntry {
+    const entry = columns.get(columnId);
+    invariant(entry);
+    return entry;
+  }
+
+  return { registerCard, registerColumn, getCard, getColumn };
+}

--- a/src/components/team/workspace/collection/content/content.tsx
+++ b/src/components/team/workspace/collection/content/content.tsx
@@ -58,7 +58,6 @@ export default function ItemContent({
       </div>
     );
   }
-  console.log("Editable:", editable);
   return (
     <NovelEditor
       content={activeItem?.content}

--- a/src/components/team/workspace/collection/content/item/create-item-cta.tsx
+++ b/src/components/team/workspace/collection/content/item/create-item-cta.tsx
@@ -2,6 +2,7 @@
 import { Spinner } from "@/components/atom/spinner";
 import useCollections from "@/lib/swr/use-collections";
 import { Collection } from "@/lib/types/types";
+import clsx from "clsx";
 import { PlusIcon } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
@@ -9,8 +10,13 @@ import { useState } from "react";
 interface CreateItemProps {
   activeCollection?: Collection;
   children: React.ReactNode;
+  className?: string;
 }
-export function CreateItemCTA({ activeCollection, children }: CreateItemProps) {
+export function CreateItemCTA({
+  activeCollection,
+  children,
+  className,
+}: CreateItemProps) {
   const { createCollection } = useCollections();
   const param = useParams();
   const router = useRouter();
@@ -24,7 +30,7 @@ export function CreateItemCTA({ activeCollection, children }: CreateItemProps) {
 
   return (
     <div
-      className="flex items-center"
+      className={clsx("flex items-center", className)}
       onClick={() => {
         if (!activeCollection || isLoading) {
           return;

--- a/src/components/team/workspace/left-panel/collection-board.tsx
+++ b/src/components/team/workspace/left-panel/collection-board.tsx
@@ -115,8 +115,7 @@ export default function CollectionBoard({
     };
     // setCollection(workValue);
   }
-  if (collections && collections.length > 0)
-    return <BoardCollectionView collections={collections} />;
+  if (collections && collections.length > 0) return <BoardCollectionView />;
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="ROOT" type="group">

--- a/src/components/team/workspace/left-panel/collection-board.tsx
+++ b/src/components/team/workspace/left-panel/collection-board.tsx
@@ -3,6 +3,7 @@ import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 
 import Label from "@/components/atom/label";
 import { P } from "@/components/atom/typography";
+import BoardCollectionView from "@/components/drag-n-drop/board-collections-view";
 import { ListView } from "@/components/ui/listview";
 import useCollections from "@/lib/swr/use-collections";
 import { hasValue } from "@/lib/utils";
@@ -114,6 +115,8 @@ export default function CollectionBoard({
     };
     // setCollection(workValue);
   }
+  if (collections && collections.length > 0)
+    return <BoardCollectionView collections={collections} />;
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="ROOT" type="group">

--- a/src/components/team/workspace/left-panel/collection-board.tsx
+++ b/src/components/team/workspace/left-panel/collection-board.tsx
@@ -231,7 +231,7 @@ function CollectionColumn({
                         }}
                       >
                         <Label size="body">
-                          {hasValue(item.name) ? item.name : "Untitled item"}
+                          {hasValue(item.name) ? item.name : "Untitled page"}
                         </Label>
                       </Link>
                     </div>
@@ -250,7 +250,7 @@ function CollectionColumn({
 export function NoCollectionView() {
   return (
     <div className="flex flex-1 flex-col place-content-center items-center">
-      <P>No items or collections</P>
+      <P>No pages or collections</P>
       <P className="text-muted-foreground">Start by creating your first item</P>
     </div>
   );

--- a/src/components/team/workspace/left-panel/collection-list.tsx
+++ b/src/components/team/workspace/left-panel/collection-list.tsx
@@ -39,6 +39,7 @@ export default function CollectionList(prop: Props) {
         className="flex flex-col gap-6 overflow-y-auto px-4 pb-28"
         items={collections}
         loading={loading}
+        sortBy={(a: Collection, b: Collection) => a.sortIndex - b.sortIndex}
         renderItem={(collection, index) => (
           <RenderCollection key={index} collection={collection} />
         )}
@@ -182,6 +183,7 @@ function RenderCollection({ collection }: RenderCollectionProps) {
 
       <ListView
         items={collection.children}
+        sortBy={(a: Collection, b: Collection) => a.sortIndex - b.sortIndex}
         className={cx(
           "ml-1 flex flex-col gap-2 border-l border-border transition-all  duration-150 ease-in-expo",
         )}

--- a/src/components/team/workspace/left-panel/collection-list.tsx
+++ b/src/components/team/workspace/left-panel/collection-list.tsx
@@ -107,7 +107,7 @@ function RenderCollection({ collection }: RenderCollectionProps) {
           href={`/${team_slug}/${workspace_slug}/${collection?.meta?.slug}`}
           className="w-full"
         >
-          <H5 className="line-clamp-1 py-1 ">
+          <H5 className="line-clamp-1 py-1.5 ">
             {hasValue(collection.name)
               ? collection.name
               : "Untitled collection"}
@@ -199,7 +199,7 @@ function RenderCollection({ collection }: RenderCollectionProps) {
         }}
         noItemsElement={
           <div className="-mx-px flex items-center gap-2  border-l border-border py-1  pl-4 text-sm font-medium text-muted-foreground/70">
-            No items
+            No pages
           </div>
         }
       />
@@ -244,7 +244,7 @@ function RenderItem({ item, collection }: RenderItemProps) {
         )}
       >
         <span className="text-sm font-medium ">
-          {hasValue(item.name) ? item.name : "Untitled item"}
+          {hasValue(item.name) ? item.name : "Untitled page"}
         </span>
       </Link>
       <WorkspacePermissionView permission="DELETE_CONTENT">

--- a/src/components/team/workspace/left-panel/collection-table.tsx
+++ b/src/components/team/workspace/left-panel/collection-table.tsx
@@ -132,7 +132,7 @@ export default function CollectionTable({
                     )}
                   >
                     <Label size="body">
-                      {hasValue(item.name) ? item.name : "Untitled item"}
+                      {hasValue(item.name) ? item.name : "Untitled page"}
                     </Label>
                   </Link>
                   <Link
@@ -160,7 +160,7 @@ export default function CollectionTable({
           }}
           noItemsElement={
             <div className="flex h-96 flex-1 flex-col place-content-center items-center">
-              <Label variant="s1">No items or collections</Label>
+              <Label variant="s1">No pages or collections</Label>
               <Label variant="s2">Start by creating your first item</Label>
             </div>
           }

--- a/src/components/ui/listview.tsx
+++ b/src/components/ui/listview.tsx
@@ -5,16 +5,23 @@ interface ListViewProps {
   items: Array<any> | undefined | null;
   renderItem: (item: any, index: number) => React.ReactNode;
   placeholder?: React.ReactNode;
-  noItemsElement?: React.ReactNode;
+  noItemsElement?: React.ReactNode | React.ReactNode[];
   footerElement?: React.ReactNode;
   className?: string;
   loading?: boolean;
+  sortBy?: (a: any, b: any) => number;
+  ref?: React.RefObject<HTMLDivElement>;
+  style?: React.CSSProperties;
 }
 
 /**
  * @name ListView Component to display a list of items
  * @description A list view component that renders a list of items.
  * @param {Array<any>} items - The list of items to be rendered
+ * @param {boolean} reversedOrder - Whether to reverse the order of the list
+ * @param {boolean} loading - Whether the list is loading
+ * @param {React.RefObject<HTMLDivElement>} ref - The ref to be used for scrolling
+ * @param {React.ReactNode} placeholder - The placeholder to be displayed when the list is empty
  * @param {React.ReactNode} renderItem - The function that renders each item
  * @param {React.ReactNode} placeholder - The placeholder to be displayed when the list is empty
  * @param {React.ReactNode} noItemsElement - The message to be displayed when the list is empty
@@ -22,7 +29,6 @@ interface ListViewProps {
  * @param {string} className - The class name to be applied to the list view
  * @returns {React.ReactNode} - The list view component
  */
-
 export const ListView: React.FC<ListViewProps> = ({
   items,
   renderItem,
@@ -31,21 +37,34 @@ export const ListView: React.FC<ListViewProps> = ({
   placeholder,
   className,
   loading = false,
+  sortBy,
+  ref,
 }) => {
   if (loading) {
     return placeholder ? <>{placeholder}</> : null;
   }
 
-  if (!items || items === null || items.length === 0 || !Array.isArray(items)) {
+  if (!items || items === null || items.length === 0) {
     if (noItemsElement) {
-      return <>{noItemsElement}</>;
+      return (
+        <>
+          {noItemsElement}
+          {footerElement && footerElement}
+        </>
+      );
     } else {
       return null;
     }
   }
+  if (sortBy && items && items.length > 0) {
+    items.sort(sortBy);
+  }
 
   return (
-    <div style={{ listStyle: "none" }} className={cx("ListView ", className)}>
+    <div
+      ref={ref}
+      className={cx("ListView", items?.length > 0 ? className : "")}
+    >
       {items.map((item, index) => renderItem(item, index))}
       {footerElement && footerElement}
     </div>

--- a/src/lib/db-schema/collection.schema.ts
+++ b/src/lib/db-schema/collection.schema.ts
@@ -5,12 +5,12 @@ import { ObjectId } from "mongodb";
 import { MetaSchema } from "./team.schema";
 
 export interface CollectionDbSchema {
-  _id: string;
+  _id: ObjectId;
   object: "item" | "collection";
   workspace: ObjectId;
   children: any;
   team: ObjectId;
-  parent: ObjectId;
+  parent: ObjectId | null;
   /**
    * @deprecated title is deprecated, use name instead
    */

--- a/src/lib/openapi/collection/index.ts
+++ b/src/lib/openapi/collection/index.ts
@@ -1,6 +1,7 @@
 import { ZodOpenApiPathsObject } from "zod-openapi";
 import { createCollection } from "./create-collection";
 import { getCollections } from "./get-collections";
+import { reorderItem } from "./reorder-item";
 
 
 export const collectionsPath: ZodOpenApiPathsObject = {
@@ -8,4 +9,7 @@ export const collectionsPath: ZodOpenApiPathsObject = {
     get: getCollections,
     post: createCollection,
   },
+  "/collections/reorder": {
+    post: reorderItem
+  }
 };

--- a/src/lib/openapi/collection/reorder-item.ts
+++ b/src/lib/openapi/collection/reorder-item.ts
@@ -1,0 +1,35 @@
+import { openApiErrorResponses } from "@/lib/openapi/responses";
+import z from "@/lib/zod";
+import { reorderCollectionResponseSchema, ReorderCollectionSchema } from "@/lib/zod/schemas";
+
+export const reorderItem = {
+  operationId: "reorderItem",
+  summary: "Reorder a collection/page",
+  description: "Reorder a collection/page within or outside a collection. This will change the order of the collection/page in the collection.",
+  requestParams: {
+    path: z.object({
+      team_slug: z.string().describe("The slug of the team."),
+      workspace_slug: z.string().describe("The slug of the workspace."),
+    }),
+  },
+  requestBody: {
+    content: {
+      "application/json": {
+        schema: ReorderCollectionSchema,
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "Reorder collection/page",
+      content: {
+        "application/json": {
+          schema: reorderCollectionResponseSchema,
+        },
+      },
+    },
+    ...openApiErrorResponses,
+  },
+  tags: ["collections"],
+  security: [{ token: [] }],
+};

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -24,6 +24,7 @@ import {
   updateUserInTeamRoleSchema,
   updateWorkspaceRoleSchema,
   updateWorkspaceSchema,
+  ReorderCollectionSchema,
 } from "../zod/schemas";
 
 export const openApiObject: ZodOpenApiObject = {
@@ -60,6 +61,7 @@ export const openApiObject: ZodOpenApiObject = {
       CollectionSchema,
       CreateCollectionSchema,
       InviteTeamMemberSchema,
+      ReorderCollectionSchema,
       SendInviteSchema,
       TeamInvitesSchema,
       TeamMemberSchema,

--- a/src/lib/swr/use-collections.ts
+++ b/src/lib/swr/use-collections.ts
@@ -10,7 +10,8 @@ import {
   removeFromCollectionTree,
   updateInCollectionTree,
 } from "../utility/collection-tree-structure";
-import { CreateCollectionSchema, UpdateCollectionSchema } from "../zod/schemas/collection";
+import { CreateCollectionSchema, UpdateCollectionSchema, reorderCollectionSchema } from "../zod/schemas/collection";
+import { z } from "zod";
 
 interface IWorkspaces {
   error: any;
@@ -25,6 +26,7 @@ interface IWorkspaces {
   createCollection(data: typeof CreateCollectionSchema._type): Promise<void>;
   updateCollection: (id: string, collection: typeof UpdateCollectionSchema._type) => Promise<Boolean>;
   UpdateItem: (item: Collection, parent: Collection) => Promise<Boolean>;
+  reorder: (args: z.infer<typeof reorderCollectionSchema>) => Promise<Boolean>;
   deleteCollection(id: string, collectionSlug: string): Promise<void>;
   deleteItem(
     id: string,
@@ -275,6 +277,53 @@ export default function useCollections(): IWorkspaces {
       });
   }
 
+  // Reorder collection/page
+  async function reorder(args: z.infer<typeof reorderCollectionSchema>): Promise<Boolean> {
+    const { team_slug, workspace_slug } = param;
+    try {
+      const response = await fetcher(
+        `/api/teams/${team_slug}/${workspace_slug}/collections/reorder`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(args),
+        },
+      );
+      let collectionTree: Collection[] = data?.collections;
+      const node = findInCollectionTree(data?.collections, (node) => node._id === args.id) as Collection;
+      if (!args.newParent) {
+        const collectionTree = updateInCollectionTree(
+          data?.collections,
+          args.id,
+          {
+            ...node,
+            sortIndex: args.index,
+          }
+        );
+      } else {
+        collectionTree = removeFromCollectionTree(data?.collections, args.id) as Collection[];
+        collectionTree = addInCollectionTree(data?.collections, args.newParent, {
+          ...node,
+          parent: args.newParent,
+          sortIndex: args.index,
+        }) as Collection[];
+      }
+      mutate(
+        { collections: collectionTree },
+        {
+          revalidate: false,
+          optimisticData: collectionTree,
+        },
+      );
+      return Promise.resolve(true);
+    } catch (error) {
+      console.error("error", error);
+      return Promise.reject(false);
+    }
+  }
+
   const activeCollection = useMemo(() => {
     if (!data?.collections) return undefined;
     return findInCollectionTree(
@@ -294,6 +343,7 @@ export default function useCollections(): IWorkspaces {
     UpdateItem,
     deleteCollection,
     deleteItem,
+    reorder,
   };
 }
 

--- a/src/lib/swr/use-collections.ts
+++ b/src/lib/swr/use-collections.ts
@@ -10,7 +10,7 @@ import {
   removeFromCollectionTree,
   updateInCollectionTree,
 } from "../utility/collection-tree-structure";
-import { CreateCollectionSchema, UpdateCollectionSchema, reorderCollectionSchema } from "../zod/schemas/collection";
+import { CreateCollectionSchema, UpdateCollectionSchema, ReorderCollectionSchema } from "../zod/schemas/collection";
 import { z } from "zod";
 
 interface IWorkspaces {
@@ -26,7 +26,7 @@ interface IWorkspaces {
   createCollection(data: typeof CreateCollectionSchema._type): Promise<void>;
   updateCollection: (id: string, collection: typeof UpdateCollectionSchema._type) => Promise<Boolean>;
   UpdateItem: (item: Collection, parent: Collection) => Promise<Boolean>;
-  reorder: (args: z.infer<typeof reorderCollectionSchema>) => Promise<Boolean>;
+  reorder: (args: z.infer<typeof ReorderCollectionSchema>) => Promise<Boolean>;
   deleteCollection(id: string, collectionSlug: string): Promise<void>;
   deleteItem(
     id: string,
@@ -278,7 +278,7 @@ export default function useCollections(): IWorkspaces {
   }
 
   // Reorder collection/page
-  async function reorder(args: z.infer<typeof reorderCollectionSchema>): Promise<Boolean> {
+  async function reorder(args: z.infer<typeof ReorderCollectionSchema>): Promise<Boolean> {
     const { team_slug, workspace_slug } = param;
     try {
       const response = await fetcher(

--- a/src/lib/zod/schemas/collection.ts
+++ b/src/lib/zod/schemas/collection.ts
@@ -56,7 +56,7 @@ export const UpdateCollectionSchema = z.object({
   }
 });
 
-export const reorderCollectionSchema = z.object({
+export const ReorderCollectionSchema = z.object({
   id: z.string().describe("The id of the collection/page to reorder."),
   parent: z.string().optional().describe("The parent collection/page id."),
   newParent: z.string().optional().describe("The new parent collection/page id."),
@@ -71,3 +71,7 @@ export const reorderCollectionSchema = z.object({
     object: 'item'
   }
 });
+
+export const reorderCollectionResponseSchema = z.object({
+  message: z.string().optional().default(""),
+})

--- a/src/lib/zod/schemas/collection.ts
+++ b/src/lib/zod/schemas/collection.ts
@@ -32,21 +32,6 @@ export const CollectionSchema = z.object({
       slug: "my-collection",
     },
   },
-}).openapi({
-  description: "A collection.",
-  example: {
-    id: "1",
-    name: "My Collection",
-    object: "collection",
-    createdAt: new Date("2021-01-01T00:00:00.000Z"),
-    updatedAt: new Date("2021-01-01T00:00:00.000Z"),
-    team: "some-team-id",
-    workspace: "some-workspace-id",
-    meta: {
-      title: "My Collection",
-      slug: "my-collection",
-    },
-  },
 });
 
 export const CreateCollectionSchema = z.object({
@@ -68,5 +53,21 @@ export const UpdateCollectionSchema = z.object({
   description: "Update a collection.",
   example: {
     name: "My updated Collection",
+  }
+});
+
+export const reorderCollectionSchema = z.object({
+  id: z.string().describe("The id of the collection/page to reorder."),
+  parent: z.string().optional().describe("The parent collection/page id."),
+  newParent: z.string().optional().describe("The new parent collection/page id."),
+  index: z.number().describe("The index to move the collection to."),
+  object: z.custom<CollectionType>().describe("Object describes the type of the collection/page . Collections will be of type 'collection' and pages will be of type 'item'."),
+}).openapi({
+  description: "Reorder a collection/page.",
+  example: {
+    id: "1",
+    parent: "2",
+    index: 3,
+    object: 'item'
   }
 });


### PR DESCRIPTION
## Summary:
This pull request introduces drag-and-drop functionality for pages and collections in the board view, allowing users to easily reorder and move items. Additionally, it includes the necessary API changes to support this feature.

## Change Log:
- Added page/collection drag and drop functionality in board view
- Implemented API to reorder/move pages from board view
- Added reorder/move API to OpenAPI specification
- Added `ctrl + s` shortcut command to save page on windows

Ref: https://github.com/Orgnise/webapp/issues/37

